### PR TITLE
Fix running the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The previous patterns didn't match, I think a concrete value is supposed
to be used instead of the $default-branch placeholder. Additionally no
branch matching is needed for pull requests I think.