### PR TITLE
Include .js extensions in internal imports explicitly

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,8 @@ module.exports = {
             statements: 100,
         },
     },
+    moduleNameMapper: {
+      "^(.*)\\.js$": "$1"
+    },
+
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './result';
-export * from './option';
+export * from './result.js';
+export * from './option.js';

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,5 +1,5 @@
-import { toString } from './utils';
-import { Result, Ok, Err } from './result';
+import { toString } from './utils.js';
+import { Result, Ok, Err } from './result.js';
 
 interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never> {
     /** `true` when the Option is Some */ readonly some: boolean;

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,5 @@
-import { toString } from './utils';
-import { Option, None, Some } from './option';
+import { toString } from './utils.js';
+import { Option, None, Some } from './option.js';
 
 /*
  * Missing Rust Result type methods:

--- a/src/rxjs-operators/index.ts
+++ b/src/rxjs-operators/index.ts
@@ -1,6 +1,6 @@
 import { MonoTypeOperatorFunction, Observable, ObservableInput, of, OperatorFunction } from 'rxjs';
 import { filter, map, mergeMap, switchMap, tap } from 'rxjs/operators';
-import { Err, Ok, Result } from '../index';
+import { Err, Ok, Result } from '../index.js';
 
 export function resultMap<T, T2, E>(mapper: (val: T) => T2): OperatorFunction<Result<T, E>, Result<T2, E>> {
     return (source) => {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'conditional-type-checks';
-import { Err, Ok } from '../src';
-import { eq, expect_never } from './util';
+import { Err, Ok } from '../src/index.js';
+import { eq, expect_never } from './util.js';
 
 test('Constructable & Callable', () => {
     const a = new Err(3);

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'conditional-type-checks';
-import { Err, Ok, Result } from '../src';
-import { eq, expect_never, expect_string } from './util';
+import { Err, Ok, Result } from '../src/index.js';
+import { eq, expect_never, expect_string } from './util.js';
 
 test('Constructable & Callable', () => {
     const a = new Ok(3);

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -1,5 +1,5 @@
-import { Err, None, Ok, Option, OptionSomeType, Result, Some } from '../src';
-import { eq } from './util';
+import { Err, None, Ok, Option, OptionSomeType, Result, Some } from '../src/index.js';
+import { eq } from './util.js';
 
 const someString = Some('foo');
 const someNum = new Some(10);

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -9,8 +9,8 @@ import {
     ResultOkType,
     ResultOkTypes,
     Some,
-} from '../src';
-import { eq } from './util';
+} from '../src/index.js';
+import { eq } from './util.js';
 
 test('Err<E> | Ok<T> should be Result<T, E>', () => {
     const r1 = Err(0);

--- a/test/rxjs.test.ts
+++ b/test/rxjs.test.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, Result } from '../src';
+import { Err, Ok, Result } from '../src/index.js';
 import { Observable, of } from 'rxjs';
 import {
     elseMap,
@@ -13,8 +13,8 @@ import {
     resultSwitchMap,
     tapResultErr,
     tapResultOk,
-} from '../src/rxjs-operators';
-import { eq } from './util';
+} from '../src/rxjs-operators/index.js';
+import { eq } from './util.js';
 
 const goodVal: Observable<Result<string, number>> = of(Ok('good'));
 const badVal: Observable<Result<string, number>> = of(Err(0));

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,5 @@
 import { IsExact, IsNever } from 'conditional-type-checks';
-import { Result } from '../src';
+import { Result } from '../src/index.js';
 import { Observable } from 'rxjs';
 
 export function expect_string<T>(x: T, y: IsExact<T, string>) {}


### PR DESCRIPTION
These imports are needed for the ESM version of the library to be
actually importable.