### PR TITLE
Restore CommonJS compatibility

### DIFF
--- a/package-cjs.json
+++ b/package-cjs.json
@@ -1,0 +1,1 @@
+{"type": "commonjs"}

--- a/package-esm.json
+++ b/package-esm.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && npm run build:ts && npm run build:copy",
     "build:ts": "tsc -p tsconfig-cjs.json && tsc -p tsconfig-esm.json",
-    "build:copy": "copyfiles README.md LICENSE src/package.json dist --flat && copyfiles src/rxjs-operators/package.json dist --up 1",
+    "build:copy": "copyfiles README.md LICENSE src/package.json dist --flat && copyfiles src/rxjs-operators/package.json dist/cjs --up 1 && cp package-cjs.json dist/cjs/package.json && cp package-esm.json dist/esm/package.json",
     "clean": "rm -rf dist",
     "test": "jest",
     "format": "prettier . --write"

--- a/src/package.json
+++ b/src/package.json
@@ -2,9 +2,15 @@
   "name": "ts-results-es",
   "version": "3.3.0",
   "description": "A typescript implementation of Rust's Result and Option objects.",
-  "main": "index.js",
-  "module": "./esm/index.js",
-  "types": "index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "exports": {
+      ".": {
+          "import": "./dist/esm/index.js",
+          "require": "./dist/cjs/index.js"
+      }
+  },
   "keywords": [
     "Rust",
     "Result",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-results-es",
-  "version": "3.3.1-alpha.0",
+  "version": "3.3.1-alpha.1",
   "description": "A typescript implementation of Rust's Result and Option objects.",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-results-es",
-  "version": "3.3.0",
+  "version": "3.3.1-alpha.0",
   "description": "A typescript implementation of Rust's Result and Option objects.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/package.json
+++ b/src/package.json
@@ -2,9 +2,9 @@
   "name": "ts-results-es",
   "version": "3.3.0",
   "description": "A typescript implementation of Rust's Result and Option objects.",
-  "exports": "./esm/index.js",
+  "main": "index.js",
+  "module": "./esm/index.js",
   "types": "index.d.ts",
-  "type": "module",
   "keywords": [
     "Rust",
     "Result",

--- a/src/package.json
+++ b/src/package.json
@@ -2,13 +2,13 @@
   "name": "ts-results-es",
   "version": "3.3.1-alpha.0",
   "description": "A typescript implementation of Rust's Result and Option objects.",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "esm/index.d.ts",
   "exports": {
       ".": {
-          "import": "./dist/esm/index.js",
-          "require": "./dist/cjs/index.js"
+          "import": "./esm/index.js",
+          "require": "./cjs/index.js"
       }
   },
   "keywords": [

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-results-es",
-  "version": "3.3.1-alpha.1",
+  "version": "3.3.0",
   "description": "A typescript implementation of Rust's Result and Option objects.",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/rxjs-operators/package.json
+++ b/src/rxjs-operators/package.json
@@ -2,5 +2,5 @@
   "name": "ts-results/rxjs-operators",
   "types": "index.d.ts",
   "main": "index.js",
-  "module": "../esm/rxjs-operators/index.js"
+  "module": "../../esm/rxjs-operators/index.js"
 }

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig-base.json",
     "compilerOptions": {
-        "outDir": "./dist/",
+        "outDir": "./dist/cjs",
         "module": "commonjs"
     }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,8 +2,6 @@
     "extends": "./tsconfig-base.json",
     "compilerOptions": {
         "outDir": "dist/esm",
-        "module": "esnext",
-        "declaration": false,
-        "declarationMap": false
+        "module": "esnext"
     }
 }


### PR DESCRIPTION
In [1] I made the package ESM-only to make it possible to import
it easily from Lune's ESM code. This is not great so I found a way
to restore the CommonJS compatibility while still resolving the
ESM-related issues[2] found in the original ts-results package.
The solution I found can be found in [3].

[1] 0be48c527e86 ("Make the package ESM-only")
[2] https://github.com/vultix/ts-results/issues/37
[3] https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html