### PR TITLE
Include error cause in unwrap()/expect() errors

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -133,11 +133,17 @@ export class ErrImpl<E> implements BaseResult<never, E> {
     }
 
     expect(msg: string): never {
-        throw new Error(`${msg} - Error: ${toString(this.val)}\n${this._stack}`);
+        // The cause casting required because of the current TS definition beign overly restrictive
+        // (the definition says it has to be an Error while it can be anything).
+        // See https://github.com/microsoft/TypeScript/issues/45167
+        throw new Error(`${msg} - Error: ${toString(this.val)}\n${this._stack}`, { cause: this.val as any });
     }
 
     unwrap(): never {
-        throw new Error(`Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`);
+        // The cause casting required because of the current TS definition beign overly restrictive
+        // (the definition says it has to be an Error while it can be anything).
+        // See https://github.com/microsoft/TypeScript/issues/45167
+        throw new Error(`Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`, { cause: this.val as any });
     }
 
     map(_mapper: unknown): Err<E> {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -53,17 +53,25 @@ test('else, unwrapOr', () => {
 });
 
 test('expect', () => {
-    expect(() => {
+    try {
         const err = Err(true).expect('should fail!');
         expect_never(err, true);
-    }).toThrowError('should fail!');
+    }
+    catch (e) {
+        expect((e as Error).message).toMatch('should fail!')
+        expect((e as Error).cause).toEqual(true)
+    }
 });
 
 test('unwrap', () => {
-    expect(() => {
+    try {
         const err = Err({ message: 'bad error' }).unwrap();
         expect_never(err, true);
-    }).toThrowError('{"message":"bad error"}');
+    }
+    catch (e) {
+        expect((e as Error).message).toMatch('{"message":"bad error"}')
+        expect((e as Error).cause).toEqual({ message: 'bad error' })
+    }
 });
 
 test('map', () => {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -56,6 +56,7 @@ test('expect', () => {
     try {
         const err = Err(true).expect('should fail!');
         expect_never(err, true);
+        throw new Error('Unreachable')
     }
     catch (e) {
         expect((e as Error).message).toMatch('should fail!')
@@ -67,6 +68,7 @@ test('unwrap', () => {
     try {
         const err = Err({ message: 'bad error' }).unwrap();
         expect_never(err, true);
+        throw new Error('Unreachable')
     }
     catch (e) {
         expect((e as Error).message).toMatch('{"message":"bad error"}')


### PR DESCRIPTION
This is useful to get access to the "underlying" error in global
exception-handling code for example.

Feature requested in [1] and I had a question about something similar as
well[2].

[1] https://github.com/vultix/ts-results/issues/34
[2] https://github.com/vultix/ts-results/issues/48

This change depends on #17 and #19 to be merged first (then the branch will be updated to contain these changes and the build will succeed).