### PR TITLE
Add the Result.expectErr() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Brings compile-time error checking and optional values to typescript.
     -   [Type Safety](#type-safety)
     -   [Unwrap](#unwrap)
     -   [Expect](#expect)
+    -   [ExpectErr](#expecterr)
     -   [Map, MapErr](#map-and-maperr)
     -   [Else](#else)
     -   [UnwrapOr](#unwrapor)
@@ -200,6 +201,17 @@ let badResult = Err(new Error('something went wrong'));
 goodResult.expect('goodResult should be a number'); // 1
 badResult.expect('badResult should be a number'); // throws Error("badResult should be a number - Error: something went wrong")
 ```
+
+#### ExpectErr
+
+```typescript
+let goodResult = Ok(1);
+let badResult = Err(new Error('something went wrong'));
+
+goodResult.expect('goodResult should not be a number'); // throws Error("goodResult should not be a number")
+badResult.expect('badResult should not be a number'); // new Error('something went wrong')
+```
+
 
 #### Map and MapErr
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ badResult.expect('badResult should be a number'); // throws Error("badResult sho
 let goodResult = Ok(1);
 let badResult = Err(new Error('something went wrong'));
 
-goodResult.expect('goodResult should not be a number'); // throws Error("goodResult should not be a number")
-badResult.expect('badResult should not be a number'); // new Error('something went wrong')
+goodResult.expectErr('goodResult should not be a number'); // throws Error("goodResult should not be a number")
+badResult.expectErr('badResult should not be a number'); // new Error('something went wrong')
 ```
 
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -26,6 +26,12 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     expect(msg: string): T;
 
     /**
+     * Returns the contained `Ok` value, if does not exist.  Throws an error if it does.
+     * @param msg the message to throw if Ok value.
+     */
+    expectErr(msg: string): T;
+    
+    /**
      * Returns the contained `Ok` value.
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `Err` case explicitly.
@@ -136,6 +142,10 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         throw new Error(`${msg} - Error: ${toString(this.val)}\n${this._stack}`);
     }
 
+    expectErr(_msg: string): E {
+        return this.val
+    }
+
     unwrap(): never {
         throw new Error(`Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`);
     }
@@ -218,6 +228,10 @@ export class OkImpl<T> implements BaseResult<T, never> {
 
     expect(_msg: string): T {
         return this.val;
+    }
+
+    expectErr(msg: string): never {
+        throw new Error(msg);
     }
 
     unwrap(): T {

--- a/src/result.ts
+++ b/src/result.ts
@@ -26,8 +26,8 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     expect(msg: string): T;
 
     /**
-     * Returns the contained `Ok` value, if does not exist.  Throws an error if it does.
-     * @param msg the message to throw if Ok value.
+     * Returns the contained `Err` value, if exists.  Throws an error if not.
+     * @param msg the message to throw if no Err value.
      */
     expectErr(msg: string): T;
     

--- a/src/result.ts
+++ b/src/result.ts
@@ -29,7 +29,7 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * Returns the contained `Err` value, if exists.  Throws an error if not.
      * @param msg the message to throw if no Err value.
      */
-    expectErr(msg: string): T;
+    expectErr(msg: string): E;
     
     /**
      * Returns the contained `Ok` value.

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -59,6 +59,12 @@ test('expect', () => {
     }).toThrowError('should fail!');
 });
 
+test('expectErr', () => {
+    const err = Err(true).expectErr('should fail!');
+    expect(err).toBe(true);
+    eq<boolean, typeof val>(true);
+});
+
 test('unwrap', () => {
     expect(() => {
         const err = Err({ message: 'bad error' }).unwrap();

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -62,7 +62,7 @@ test('expect', () => {
 test('expectErr', () => {
     const err = Err(true).expectErr('should fail!');
     expect(err).toBe(true);
-    eq<boolean, typeof val>(true);
+    eq<boolean, typeof err>(true);
 });
 
 test('unwrap', () => {

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -59,6 +59,13 @@ test('expect', () => {
     eq<boolean, typeof val>(true);
 });
 
+test('expectErr', () => {
+    expect(() => {
+        const val = Ok(true).expectErr('should fail!');
+        expect_never(val, true);
+    }).toThrowError('should fail!');
+});
+
 test('unwrap', () => {
     const val = Ok(true).unwrap();
     expect(val).toBe(true);


### PR DESCRIPTION
This is a port of https://github.com/vultix/ts-results/pull/45
to the ts-results-es fork, original author: TheDudeFromCI.

This is a feature useful for testing (where one *expects* an error
in some cases and wants an exception thrown otherwise).