### PR TITLE
Implement mapOr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ badResult
     .unwrap(); // throws Error("mapped")
 ```
 
+#### MapOr
+
+```typescript
+let goodResult = Ok(1);
+let badResult = Err(new Error('something went wrong'));
+
+goodResult.mapOr(0, (value) => -value) // -1
+badResult.mapOr(0, (value) => -value) // 0
+```
+
 #### andThen
 
 ```typescript

--- a/src/option.ts
+++ b/src/option.ts
@@ -42,6 +42,12 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
     map<U>(mapper: (val: T) => U): Option<U>;
 
     /**
+     * Maps an `Option<T>` to `Option<U>` by either converting `T` to `U` using `mapper` (in case
+     * of `Some`) or using the `default_` value (in case of `None`).
+     */
+    mapOr<U>(default_: U, mapper: (val: T) => U): U;
+
+    /**
      * Maps an `Option<T>` to a `Result<T, E>`.
      */
     toResult<E>(error: E): Result<T, E>;
@@ -74,8 +80,12 @@ class NoneImpl implements BaseOption<never> {
         throw new Error(`Tried to unwrap None`);
     }
 
-    map<T2>(_mapper: unknown): None {
+    map(_mapper: unknown): None {
         return this;
+    }
+
+    mapOr<T2>(default_: T2, _mapper: unknown): T2 {
+        return default_;
     }
 
     andThen<T2>(op: unknown): None {
@@ -145,6 +155,10 @@ class SomeImpl<T> implements BaseOption<T> {
 
     map<T2>(mapper: (val: T) => T2): Some<T2> {
         return Some(mapper(this.val));
+    }
+
+    mapOr<T2>(_default_: T2, mapper: (val: T) => T2): T2 {
+        return mapper(this.val);
     }
 
     andThen<T2>(mapper: (val: T) => Option<T2>): Option<T2> {

--- a/src/option.ts
+++ b/src/option.ts
@@ -80,7 +80,7 @@ class NoneImpl implements BaseOption<never> {
         throw new Error(`Tried to unwrap None`);
     }
 
-    map(_mapper: unknown): None {
+    map<T2>(_mapper: unknown): None {
         return this;
     }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -5,7 +5,6 @@ import { Option, None, Some } from './option.js';
  * Missing Rust Result type methods:
  * pub fn contains<U>(&self, x: &U) -> bool
  * pub fn contains_err<F>(&self, f: &F) -> bool
- * pub fn map_or<U, F>(self, default: U, f: F) -> U
  * pub fn map_or_else<U, D, F>(self, default: D, f: F) -> U
  * pub fn and<U>(self, res: Result<U, E>) -> Result<U, E>
  * pub fn or<F>(self, res: Result<T, F>) -> Result<T, F>
@@ -79,6 +78,12 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * This function can be used to pass through a successful result while handling an error.
      */
     mapErr<F>(mapper: (val: E) => F): Result<T, F>;
+
+    /**
+     * Maps a `Result<T, E>` to `Result<U, E>` by either converting `T` to `U` using `mapper`
+     * (in case of `Ok`) or using the `default_` value (in case of `Err`).
+     */
+    mapOr<U>(default_: U, mapper: (val: T) => U): U;
 
     /**
      *  Converts from `Result<T, E>` to `Option<T>`, discarding the error if any
@@ -166,6 +171,10 @@ export class ErrImpl<E> implements BaseResult<never, E> {
 
     mapErr<E2>(mapper: (err: E) => E2): Err<E2> {
         return new Err(mapper(this.val));
+    }
+
+    mapOr<U>(default_: U, _mapper: unknown): U {
+        return default_;
     }
 
     toOption(): Option<never> {
@@ -257,6 +266,10 @@ export class OkImpl<T> implements BaseResult<T, never> {
 
     mapErr(_mapper: unknown): Ok<T> {
         return this;
+    }
+
+    mapOr<U>(_default_: U, mapper: (val: T) => U): U {
+        return mapper(this.val);
     }
 
     toOption(): Option<T> {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -100,6 +100,10 @@ test('mapErr', () => {
     eq<typeof err, Err<number>>(true);
 });
 
+test('mapOr', () => {
+    expect(Err('Some error').mapOr(1, () => -1)).toEqual(1)
+});
+
 test('iterable', () => {
     for (const item of Err([123])) {
         expect_never(item, true);

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -94,6 +94,10 @@ test('mapErr', () => {
     eq<typeof ok, Ok<string>>(true);
 });
 
+test('mapOr', () => {
+    expect(Ok(11).mapOr(1, (val) => val * 2)).toEqual(22)
+});
+
 test('iterable', () => {
     let i = 0;
     for (const char of Ok('hello')) {

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -77,6 +77,11 @@ test('map / andThen', () => {
     eq<typeof mapped, Option<boolean>>(true);
 });
 
+test('mapOr', () => {
+    expect(None.mapOr(1, () => -1)).toEqual(1)
+    expect(Some(11).mapOr(1, (val) => val * 2)).toEqual(22)
+});
+
 test('all / any', () => {
     const strings = ['foo', 'bar', 'baz'] as const;
     const options = [Some('foo' as const), Some('bar' as const), Some('baz' as const)] as const;


### PR DESCRIPTION
This is a useful composition mechanism when we want to both provide a
default value or map an existing value in the same operation.