### PR TITLE
Implement mapOrElse() on Option and Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ badResult
     .unwrap(); // throws Error("mapped")
 ```
 
-#### MapOr
+#### MapOr and MapOrElse
 
 ```typescript
 let goodResult = Ok(1);
@@ -254,6 +254,11 @@ let badResult = Err(new Error('something went wrong'));
 
 goodResult.mapOr(0, (value) => -value) // -1
 badResult.mapOr(0, (value) => -value) // 0
+
+// mapOrElse() is useful when you only want to call the default function
+// when it's necessary (if it performs some heavy computation for example).
+goodResult.mapOrElse(() => 0, (value) => -value) // -1
+badResult.mapOrElse(() => 0, (value) => -value) // 0
 ```
 
 #### andThen

--- a/src/option.ts
+++ b/src/option.ts
@@ -44,8 +44,17 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
     /**
      * Maps an `Option<T>` to `Option<U>` by either converting `T` to `U` using `mapper` (in case
      * of `Some`) or using the `default_` value (in case of `None`).
+     *
+     * If `default` is a result of a function call consider using `mapOrElse` instead, it will
+     * only evaluate the function when needed.
      */
     mapOr<U>(default_: U, mapper: (val: T) => U): U;
+
+    /**
+     * Maps an `Option<T>` to `Option<U>` by either converting `T` to `U` using `mapper` (in case
+     * of `Some`) or producing a default value using the `default` function (in case of `None`).
+     */
+    mapOrElse<U>(default_: () => U, mapper: (val: T) => U): U;
 
     /**
      * Maps an `Option<T>` to a `Result<T, E>`.
@@ -86,6 +95,10 @@ class NoneImpl implements BaseOption<never> {
 
     mapOr<T2>(default_: T2, _mapper: unknown): T2 {
         return default_;
+    }
+
+    mapOrElse<U>(default_: () => U, _mapper: unknown): U {
+        return default_();
     }
 
     andThen<T2>(op: unknown): None {
@@ -158,6 +171,8 @@ class SomeImpl<T> implements BaseOption<T> {
     }
 
     mapOr<T2>(_default_: T2, mapper: (val: T) => T2): T2 {
+
+    mapOrElse<U>(_default_: () => U, mapper: (val: T) => U): U {
         return mapper(this.val);
     }
 

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -100,8 +100,9 @@ test('mapErr', () => {
     eq<typeof err, Err<number>>(true);
 });
 
-test('mapOr', () => {
+test('mapOr / mapOrElse', () => {
     expect(Err('Some error').mapOr(1, () => -1)).toEqual(1)
+    expect(Err('Some error').mapOrElse(() => 1, () => -1)).toEqual(1)
 });
 
 test('iterable', () => {

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -94,8 +94,9 @@ test('mapErr', () => {
     eq<typeof ok, Ok<string>>(true);
 });
 
-test('mapOr', () => {
+test('mapOr / mapOrElse', () => {
     expect(Ok(11).mapOr(1, (val) => val * 2)).toEqual(22)
+    expect(Ok(11).mapOrElse(() => 1, (val) => val * 2)).toEqual(22)
 });
 
 test('iterable', () => {

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -77,9 +77,12 @@ test('map / andThen', () => {
     eq<typeof mapped, Option<boolean>>(true);
 });
 
-test('mapOr', () => {
+test('mapOr / mapOrElse', () => {
     expect(None.mapOr(1, () => -1)).toEqual(1)
+    expect(None.mapOrElse(() => 1, () => -1)).toEqual(1)
+
     expect(Some(11).mapOr(1, (val) => val * 2)).toEqual(22)
+    expect(Some(11).mapOrElse(() => { throw new Error('Should not happen'); }, (val) => val * 2)).toEqual(22)
 });
 
 test('all / any', () => {


### PR DESCRIPTION
Similarly to [1] it increases the number of ways in which values can be
extracted out of Results and Options without having to write conditional
code. This variant allows for optimizing function calls as no calls to
default will be made unless necessary.

[1] 602589839eec ("Implement mapOr() (#23)")