### PR TITLE
Add a missing readme index link for mapOr()/mapOrElse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ can become obsolete.
     -   [Expect](#expect)
     -   [ExpectErr](#expecterr)
     -   [Map, MapErr](#map-and-maperr)
+    -   [MapOr, MapOrElse](#mapor-and-maporelse)
     -   [AndThen](#andthen)
     -   [Else](#else)
     -   [UnwrapOr](#unwrapor)


### PR DESCRIPTION
I forgot to put it there when I added mapOr().