### PR TITLE
Implement Result.unwrapErr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ can become obsolete.
     -   [Creation](#creation)
     -   [Type Safety](#type-safety)
     -   [Unwrap](#unwrap)
+    -   [UnwrapErr](#unwraperr)
     -   [Expect](#expect)
     -   [ExpectErr](#expecterr)
     -   [Map, MapErr](#map-and-maperr)
@@ -208,6 +209,17 @@ let badResult = new Err(new Error('something went wrong'));
 goodResult.unwrap(); // 1
 badResult.unwrap(); // throws Error("something went wrong")
 ```
+
+#### UnwrapErr
+
+```typescript
+let goodResult = new Ok(1);
+let badResult = new Err('something went wrong');
+
+goodResult.unwrapErr(); // throws an exception
+badResult.unwrapErr(); // returns 'something went wrong'
+```
+
 
 #### Expect
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -10,7 +10,6 @@ import { Option, None, Some } from './option.js';
  * pub fn or_else<F, O>(self, op: O) -> Result<T, F>
  * pub fn unwrap_or_else<F>(self, op: F) -> T
  * pub fn expect_err(self, msg: &str) -> E
- * pub fn unwrap_err(self) -> E
  * pub fn unwrap_or_default(self) -> T
  */
 interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : never> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -39,6 +39,15 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     unwrap(): T;
 
     /**
+     * Returns the contained `Err` value.
+     * Because this function may throw, its use is generally discouraged.
+     * Instead, prefer to handle the `Ok` case explicitly.
+     *
+     * Throws if the value is an `Ok`, with a message provided by the `Ok`'s value.
+     */
+    unwrapErr(): E;
+
+    /**
      * Returns the contained `Ok` value or a provided default.
      *
      *  @see unwrapOr
@@ -170,6 +179,10 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         throw new Error(`Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`, { cause: this.val as any });
     }
 
+    unwrapErr(): E {
+        return this.val;
+    }
+
     map(_mapper: unknown): Err<E> {
         return this;
     }
@@ -264,6 +277,13 @@ export class OkImpl<T> implements BaseResult<T, never> {
 
     unwrap(): T {
         return this.val;
+    }
+
+    unwrapErr(): never {
+        // The cause casting required because of the current TS definition beign overly restrictive
+        // (the definition says it has to be an Error while it can be anything).
+        // See https://github.com/microsoft/TypeScript/issues/45167
+        throw new Error(`Tried to unwrap Ok: ${toString(this.val)}`, { cause: this.val as any });
     }
 
     map<T2>(mapper: (val: T) => T2): Ok<T2> {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -83,9 +83,9 @@ test('unwrap', () => {
 });
 
 test('unwrapErr', () => {
-    cconst err = Err(1).unwrapErr();
-    expect(val).toBe(1);
-    eq<number, typeof val>(true);
+    const err = Err(1).unwrapErr();
+    expect(err).toBe(1);
+    eq<number, typeof err>(true);
 });
 
 test('map', () => {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -82,6 +82,12 @@ test('unwrap', () => {
     }
 });
 
+test('unwrapErr', () => {
+    cconst err = Err(1).unwrapErr();
+    expect(val).toBe(1);
+    eq<number, typeof val>(true);
+});
+
 test('map', () => {
     const err = Err(3).map((x: any) => Symbol());
     expect(err).toMatchResult(Err(3));

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -74,13 +74,13 @@ test('unwrap', () => {
 
 test('unwrapErr', () => {
     try {
-        const err = Ok(1).unwrapErr();
+        const err = Ok('boom').unwrapErr();
         expect_never(err, true);
         throw new Error('Unreachable')
     }
     catch (e) {
-        expect((e as Error).message).toMatch(1)
-        expect((e as Error).cause).toEqual(1)
+        expect((e as Error).message).toMatch('boom')
+        expect((e as Error).cause).toEqual('boom')
     }
 });
 

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -72,6 +72,18 @@ test('unwrap', () => {
     eq<boolean, typeof val>(true);
 });
 
+test('unwrapErr', () => {
+    try {
+        const err = Ok(1).unwrapErr();
+        expect_never(err, true);
+        throw new Error('Unreachable')
+    }
+    catch (e) {
+        expect((e as Error).message).toMatch(1)
+        expect((e as Error).cause).toEqual(1)
+    }
+});
+
 test('map', () => {
     const mapped = Ok(3).map((x) => x.toString(10));
     expect(mapped).toMatchResult(Ok('3'));


### PR DESCRIPTION
It's one of the functions that's been missing from the API and
we wanted to use it a few times already when we check for errors
in tests.

Closes GH-27.