### PR TITLE
Nudge unwrap()/except() users towards val

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -7,6 +7,12 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
 
     /**
      * Returns the contained `Some` value, if exists.  Throws an error if not.
+     *
+     * If you know you're dealing with `Some` and the compiler knows it too you should use
+     * `val` instead. While `expect()` and `val` on `Some` will both return the same value
+     * using `val` is preferable because it makes it clear that there won't be an exception
+     * thrown on access.
+     *
      * @param msg the message to throw if no Some value.
      */
     expect(msg: string): T;
@@ -15,6 +21,11 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * Returns the contained `Some` value.
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `None` case explicitly.
+     *
+     * If you know you're dealing with `Some` and the compiler knows it too you should use
+     * `val` instead. While `unwrap()` and `val` on `Some` will both return the same value
+     * using `val` is preferable because it makes it clear that there won't be an exception
+     * thrown on access.
      *
      * Throws if the value is `None`.
      */

--- a/src/option.ts
+++ b/src/option.ts
@@ -8,10 +8,10 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
     /**
      * Returns the contained `Some` value, if exists.  Throws an error if not.
      *
-     * If you know you're dealing with `Some` and the compiler knows it too you should use
-     * `val` instead. While `expect()` and `val` on `Some` will both return the same value
-     * using `val` is preferable because it makes it clear that there won't be an exception
-     * thrown on access.
+     * If you know you're dealing with `Some` and the compiler knows it too (because you tested
+     * `some` or `none`) you should use `val` instead. While `Some`'s `expect()` and `val` will
+     * both return the same value using `val` is preferable because it makes it clear that
+     * there won't be an exception thrown on access.
      *
      * @param msg the message to throw if no Some value.
      */
@@ -22,10 +22,10 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `None` case explicitly.
      *
-     * If you know you're dealing with `Some` and the compiler knows it too you should use
-     * `val` instead. While `unwrap()` and `val` on `Some` will both return the same value
-     * using `val` is preferable because it makes it clear that there won't be an exception
-     * thrown on access.
+     * If you know you're dealing with `Some` and the compiler knows it too (because you tested
+     * `some` or `none`) you should use `val` instead. While `Some`'s `unwrap()` and `val` will
+     * both return the same value using `val` is preferable because it makes it clear that
+     * there won't be an exception thrown on access.
      *
      * Throws if the value is `None`.
      */

--- a/src/result.ts
+++ b/src/result.ts
@@ -16,6 +16,12 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
 
     /**
      * Returns the contained `Ok` value, if exists.  Throws an error if not.
+     *
+     * If you know you're dealing with `Ok` and the compiler knows it too you should use
+     * `val` instead. While `expect()` and `val` on `Ok` will both return the same value
+     * using `val` is preferable because it makes it clear that there won't be an exception
+     * thrown on access.
+     *
      * @param msg the message to throw if no Ok value.
      */
     expect(msg: string): T;
@@ -30,6 +36,11 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * Returns the contained `Ok` value.
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `Err` case explicitly.
+     *
+     * If you know you're dealing with `Ok` and the compiler knows it too you should use
+     * `val` instead. While `unwrap()` and `val` on `Ok` will both return the same value
+     * using `val` is preferable because it makes it clear that there won't be an exception
+     * thrown on access.
      *
      * Throws if the value is an `Err`, with a message provided by the `Err`'s value.
      */

--- a/src/result.ts
+++ b/src/result.ts
@@ -17,10 +17,10 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     /**
      * Returns the contained `Ok` value, if exists.  Throws an error if not.
      *
-     * If you know you're dealing with `Ok` and the compiler knows it too you should use
-     * `val` instead. While `expect()` and `val` on `Ok` will both return the same value
-     * using `val` is preferable because it makes it clear that there won't be an exception
-     * thrown on access.
+     * If you know you're dealing with `Ok` and the compiler knows it too (because you tested
+     * `ok` or `err`) you should use `val` instead. While `Ok`'s `expect()` and `val` will
+     * both return the same value using `val` is preferable because it makes it clear that
+     * there won't be an exception thrown on access.
      *
      * @param msg the message to throw if no Ok value.
      */
@@ -37,10 +37,10 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `Err` case explicitly.
      *
-     * If you know you're dealing with `Ok` and the compiler knows it too you should use
-     * `val` instead. While `unwrap()` and `val` on `Ok` will both return the same value
-     * using `val` is preferable because it makes it clear that there won't be an exception
-     * thrown on access.
+     * If you know you're dealing with `Ok` and the compiler knows it too (because you tested
+     * `ok` or `err`) you should use `val` instead. While `Ok`'s `unwrap()` and `val` will
+     * both return the same value using `val` is preferable because it makes it clear that
+     * there won't be an exception thrown on access.
      *
      * Throws if the value is an `Err`, with a message provided by the `Err`'s value.
      */


### PR DESCRIPTION
See the docstrings for details, basically if it's statically safe to use val it should be used because it's obvious there's a value there and there won't be an exception (unwrap()/except() are conditional and may throw, val isn't).