### PR TITLE
Synchronize the package.json metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ts-results-es",
       "version": "3.6.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.22",
         "conditional-type-checks": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,26 @@
     "type": "git",
     "url": "https://github.com/lune-climate/ts-results-es.git"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "Rust",
+    "Result",
+    "Results",
+    "Option",
+    "Options",
+    "Typescript",
+    "TS",
+    "Ok",
+    "Err",
+    "Some",
+    "None",
+    "Typed Errors",
+    "Error Handling",
+    "Monad",
+    "Maybe",
+    "Union"
+  ],
+  "author": "Vultix",
+  "license": "MIT",
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "conditional-type-checks": "^1.0.5",
@@ -28,5 +45,6 @@
     "ts-jest": "^26.5.4",
     "tslib": "^2.3.1",
     "typescript": "^4.6.3"
-  }
+  },
+  "readme": "README.md"
 }


### PR DESCRIPTION
We currently have two package.json files which I want to remove but first let's make sure that they're consistent to the extent that it's applicable.

The license is an important point and it seems that the MIT has always been the correct one as the LICENSE file has it too.