### PR TITLE
Fix rxjs-operators submodule support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
       ".": {
           "import": "./dist/esm/index.js",
           "require": "./dist/cjs/index.js"
+      },
+      "./rxjs-operators": {
+        "types": "./dist/esm/rxjs-operators/index.d.ts",
+        "import": "./dist/esm/rxjs-operators/index.js",
+        "require": "./dist/cjs/rxjs-operators/index.js"
       }
   },
   "repository": {


### PR DESCRIPTION
After some of my changes[1][2] it stopped being possible to import the ts-results-es/rxjs-operators submodule[3].

Cherry-picked from [4] by Jacob Nguyen.

I tested it locally and it worked for me.

[1] 0be48c527e86 ("Make the package ESM-only")
[2] befb3c555552 ("Restore CommonJS compatibility (#5)")
[3] https://github.com/lune-climate/ts-results-es/issues/38
[4] https://github.com/lune-climate/ts-results-es/pull/39