### PR TITLE
Add Option.of for convenient Option construction

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -308,4 +308,8 @@ export namespace Option {
     export function isOption<T = any>(value: unknown): value is Option<T> {
         return value instanceof Some || value === None;
     }
+
+    export function of<T>(value: T | null | undefined): Option<T> {
+        return value === null || value === undefined ? None : Some(value);
+    }
 }

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -135,3 +135,9 @@ test('or / orElse', () => {
     expect(Some(1).or(Some(2))).toEqual(Some(1))
     expect(Some(1).orElse(() => {throw new Error('Call unexpected')})).toEqual(Some(1))
 })
+
+test('of', () => {
+    expect(Option.of(1)).toEqual(Some(1));
+    expect(Option.of(null)).toEqual(None);
+    expect(Option.of(undefined)).toEqual(None);
+});


### PR DESCRIPTION
This PR adds a convenience function to the `Option` namespace
that allows for easy construction of `Option` types.

The logic is slightly opinionated in the sense that only `null` and `undefined`
are considered `None`, though I'd argue this is as close to a universal agreement
in Javascript as we are likely to get.
