### PR TITLE
Document the unwrapX() behavior regarding the error cause

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -42,7 +42,9 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * both return the same value using `val` is preferable because it makes it clear that
      * there won't be an exception thrown on access.
      *
-     * Throws if the value is an `Err`, with a message provided by the `Err`'s value.
+     * Throws if the value is an `Err`, with a message provided by the `Err`'s value and
+     * [`cause'](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
+     * set to the value.
      */
     unwrap(): T;
 
@@ -51,7 +53,9 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `Ok` case explicitly.
      *
-     * Throws if the value is an `Ok`, with a message provided by the `Ok`'s value.
+     * Throws if the value is an `Ok`, with a message provided by the `Ok`'s value and
+     * [`cause'](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
+     * set to the value.
      */
     unwrapErr(): E;
 


### PR DESCRIPTION
When I modified unwrap()[1] and added unwrapErr()[2] I didn't document the fact that the exceptions thrown there have their cause[3] set to the original value so that the exception handling code can make decisions based on that.

Let's rectify that.

[1] 73a700ee4894 ("Include error cause in unwrap()/expect() errors (#20)")
[2] e6d5012cc12b ("Implement Result.unwrapErr() (#28)")
[3] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause