### PR TITLE
Fix the type declaration files' locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,12 @@
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
   "exports": {
       ".": {
           "import": "./dist/esm/index.js",
           "require": "./dist/cjs/index.js"
       },
       "./rxjs-operators": {
-        "types": "./dist/esm/rxjs-operators/index.d.ts",
         "import": "./dist/esm/rxjs-operators/index.js",
         "require": "./dist/cjs/rxjs-operators/index.js"
       }


### PR DESCRIPTION
arethetypeswrong[1] detected two issues in the last release of this package, both when importing the rxjs-operators submodule from CJS code in node16 module resolution mode[2]:

* Masquerading as ESM
* ESM (dynamic import only)

They document this stuff really well. In our case the problam has been we've always been using ESM type declarations regardless of the mode (CJS or ESM).

[3] shows that the "types" declarations can be ommitted if the .cjs/.mjs/.js files have corresponding .d.ts files living in the same directories – which in our case they do:

    root@06bb8ded2f98:/lune/ts-results-es# tree dist
    dist
    |-- cjs
    |   |-- index.d.ts
    |   |-- index.d.ts.map
    |   |-- index.js
    |   |-- index.js.map
    |   |-- option.d.ts
    |   |-- option.d.ts.map
    |   |-- option.js
    |   |-- option.js.map
    |   |-- package.json
    |   |-- result.d.ts
    |   |-- result.d.ts.map
    |   |-- result.js
    |   |-- result.js.map
    |   |-- rxjs-operators
    |   |   |-- index.d.ts
    |   |   |-- index.d.ts.map
    |   |   |-- index.js
    |   |   |-- index.js.map
    |   |   `-- package.json
    |   |-- utils.d.ts
    |   |-- utils.d.ts.map
    |   |-- utils.js
    |   `-- utils.js.map
    `-- esm
        |-- index.d.ts
        |-- index.d.ts.map
        |-- index.js
        |-- index.js.map
        |-- option.d.ts
        |-- option.d.ts.map
        |-- option.js
        |-- option.js.map
        |-- package.json
        |-- result.d.ts
        |-- result.d.ts.map
        |-- result.js
        |-- result.js.map
        |-- rxjs-operators
        |   |-- index.d.ts
        |   |-- index.d.ts.map
        |   |-- index.js
        |   `-- index.js.map
        |-- utils.d.ts
        |-- utils.d.ts.map
        |-- utils.js
        `-- utils.js.map

    5 directories, 43 files

And then the compiler will do the right thing and use the appropriate type declarations – CJS or ESM – depending on the import type.

Read the whole document[3] if you're interested. I verified that this change works by uploading the new version to [1] and by building our backend with it.

This patch fixes both of the issues reported in [2].

[1] https://arethetypeswrong.github.io
[2] https://arethetypeswrong.github.io/?p=ts-results-es%403.6.1
[3] https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/4786ef2571de5772cece4c671847456b9746437e/docs/problems/FalseESM.md#common-causes