### PR TITLE
Rename Some.val to value

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Notable changes compared to the original package:
 * `Result` also gained extra methods: `mapOr()`, `mapOrElse()`,
   `expectErr()`, `or()`, `orElse()`
 * `Ok` and `Err` no longer have the `val` property – it's `Ok.value` and `Err.error` now
+* There is `Some.value` which replaced `Some.val`
 
 We'll try to get the changes merged into the upstream package so that this fork
 can become obsolete.
@@ -157,7 +158,7 @@ console.log(optionalUrl); // Some(URL('...'))
 
 // To extract the value, do this:
 if (optionalUrl.some) {
-    const url: URL = optionalUrl.val;
+    const url: URL = optionalUrl.value;
 }
 ```
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -172,13 +172,13 @@ class SomeImpl<T> implements BaseOption<T> {
 
     readonly some!: true;
     readonly none!: false;
-    readonly val!: T;
+    readonly value!: T;
 
     /**
      * Helper function if you know you have an Some<T> and T is iterable
      */
     [Symbol.iterator](): Iterator<T extends Iterable<infer U> ? U : never> {
-        const obj = Object(this.val) as Iterable<any>;
+        const obj = Object(this.value) as Iterable<any>;
 
         return Symbol.iterator in obj
             ? obj[Symbol.iterator]()
@@ -196,31 +196,31 @@ class SomeImpl<T> implements BaseOption<T> {
 
         this.some = true;
         this.none = false;
-        this.val = val;
+        this.value = val;
     }
 
     unwrapOr(_val: unknown): T {
-        return this.val;
+        return this.value;
     }
 
     expect(_msg: string): T {
-        return this.val;
+        return this.value;
     }
 
     unwrap(): T {
-        return this.val;
+        return this.value;
     }
 
     map<T2>(mapper: (val: T) => T2): Some<T2> {
-        return Some(mapper(this.val));
+        return Some(mapper(this.value));
     }
 
     mapOr<T2>(_default_: T2, mapper: (val: T) => T2): T2 {
-        return mapper(this.val);
+        return mapper(this.value);
     }
 
     mapOrElse<U>(_default_: () => U, mapper: (val: T) => U): U {
-        return mapper(this.val);
+        return mapper(this.value);
     }
 
     or(_other: Option<T>): Option<T> {
@@ -232,11 +232,11 @@ class SomeImpl<T> implements BaseOption<T> {
     }
 
     andThen<T2>(mapper: (val: T) => Option<T2>): Option<T2> {
-        return mapper(this.val);
+        return mapper(this.value);
     }
 
     toResult<E>(error: E): Ok<T> {
-        return Ok(this.val);
+        return Ok(this.value);
     }
 
     /**
@@ -249,11 +249,11 @@ class SomeImpl<T> implements BaseOption<T> {
      * (this is the `into_Some()` in rust)
      */
     safeUnwrap(): T {
-        return this.val;
+        return this.value;
     }
 
     toString(): string {
-        return `Some(${toString(this.val)})`;
+        return `Some(${toString(this.value)})`;
     }
 }
 
@@ -278,7 +278,7 @@ export namespace Option {
         const someOption = [];
         for (let option of options) {
             if (option.some) {
-                someOption.push(option.val);
+                someOption.push(option.value);
             } else {
                 return option as None;
             }

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -8,8 +8,8 @@ test('basic invariants', () => {
     expect(someString.some).toBeTruthy();
     expect(someNum.some).toBeTruthy();
     expect(None).toBe(None);
-    expect(someString.val).toBe('foo');
-    expect(someNum.val).toBe(10);
+    expect(someString.value).toBe('foo');
+    expect(someNum.value).toBe(10);
 
     expect(Option.isOption(someString)).toBe(true);
     expect(Option.isOption(someNum)).toBe(true);
@@ -21,7 +21,7 @@ test('type narrowing', () => {
     const opt = None as Option<string>;
     if (opt.some) {
         eq<typeof opt, Some<string>>(true);
-        eq<typeof opt.val, string>(true);
+        eq<typeof opt.value, string>(true);
     } else {
         eq<typeof opt, None>(true);
     }
@@ -30,19 +30,19 @@ test('type narrowing', () => {
         eq<typeof opt, None>(true);
     } else {
         eq<typeof opt, Some<string>>(true);
-        eq<typeof opt.val, string>(true);
+        eq<typeof opt.value, string>(true);
     }
 
     if (opt.none) {
         eq<typeof opt, None>(true);
     } else {
         eq<typeof opt, Some<string>>(true);
-        eq<typeof opt.val, string>(true);
+        eq<typeof opt.value, string>(true);
     }
 
     if (!opt.none) {
         eq<typeof opt, Some<string>>(true);
-        eq<typeof opt.val, string>(true);
+        eq<typeof opt.value, string>(true);
     } else {
         eq<typeof opt, None>(true);
     }


### PR DESCRIPTION
We've done something similar to Ok/Err in [1] so I figured we could change this one too to keep things consistent.

The change is backwards incompatible but in an explicit way – the code using the old name will fail to compile.

We'll document the migration steps for the client code.

[1] c0c3f6c487c1 ("Stop reusing the val property in Ok and Err (#58)")