### PR TITLE
Fix the property names in the documentation

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -12,8 +12,8 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * Returns the contained `Some` value, if exists.  Throws an error if not.
      *
      * If you know you're dealing with `Some` and the compiler knows it too (because you tested
-     * `some` or `none`) you should use `val` instead. While `Some`'s `expect()` and `val` will
-     * both return the same value using `val` is preferable because it makes it clear that
+     * `isSome()` or `isNone()`) you should use `value` instead. While `Some`'s `expect()` and `value` will
+     * both return the same value using `value` is preferable because it makes it clear that
      * there won't be an exception thrown on access.
      *
      * @param msg the message to throw if no Some value.
@@ -26,8 +26,8 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * Instead, prefer to handle the `None` case explicitly.
      *
      * If you know you're dealing with `Some` and the compiler knows it too (because you tested
-     * `some` or `none`) you should use `val` instead. While `Some`'s `unwrap()` and `val` will
-     * both return the same value using `val` is preferable because it makes it clear that
+     * `isSome()` or `isNone()`) you should use `value` instead. While `Some`'s `unwrap()` and `value` will
+     * both return the same value using `value` is preferable because it makes it clear that
      * there won't be an exception thrown on access.
      *
      * Throws if the value is `None`.

--- a/src/result.ts
+++ b/src/result.ts
@@ -25,8 +25,8 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * is set to value contained in `Err`.
      *
      * If you know you're dealing with `Ok` and the compiler knows it too (because you tested
-     * `ok` or `err`) you should use `val` instead. While `Ok`'s `expect()` and `val` will
-     * both return the same value using `val` is preferable because it makes it clear that
+     * `isOk()` or `isErr()`) you should use `value` instead. While `Ok`'s `expect()` and `value` will
+     * both return the same value using `value` is preferable because it makes it clear that
      * there won't be an exception thrown on access.
      *
      * @param msg the message to throw if no Ok value.
@@ -45,8 +45,8 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * Instead, prefer to handle the `Err` case explicitly.
      *
      * If you know you're dealing with `Ok` and the compiler knows it too (because you tested
-     * `ok` or `err`) you should use `val` instead. While `Ok`'s `unwrap()` and `val` will
-     * both return the same value using `val` is preferable because it makes it clear that
+     * `isOk()` or `isErr()`) you should use `value` instead. While `Ok`'s `unwrap()` and `value` will
+     * both return the same value using `value` is preferable because it makes it clear that
      * there won't be an exception thrown on access.
      *
      * Throws if the value is an `Err`, with a message provided by the `Err`'s value and


### PR DESCRIPTION
I forgot to keep them up to date when applying [1], [2] and [3].

[1] c0c3f6c487c1 ("Stop reusing the val property in Ok and Err (#58)")
[2] b1869369ec35 ("Rename Some.val to value (#66)")
[3] e30395e39e70 ("Replace boolean Option/Result flags with more Rust-like methods (#67)")