### PR TITLE
refactor: edit copy script and remove unneeded package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run clean && npm run build:ts && npm run build:copy",
     "build:ts": "tsc -p tsconfig-cjs.json && tsc -p tsconfig-esm.json",
-    "build:copy": "copyfiles src/rxjs-operators/package.json dist/cjs --up 1 && cp package-cjs.json dist/cjs/package.json && cp package-esm.json dist/esm/package.json",
+    "build:copy": "cp package-cjs.json dist/cjs/package.json && cp package-esm.json dist/esm/package.json",
     "clean": "rm -rf dist",
     "test": "jest",
     "format": "prettier . --write"

--- a/src/rxjs-operators/package.json
+++ b/src/rxjs-operators/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "ts-results/rxjs-operators",
-  "types": "index.d.ts",
-  "main": "index.js",
-  "module": "../../esm/rxjs-operators/index.js"
-}


### PR DESCRIPTION
- rxjs-operators package.json is unneeded, its just extra and unnecessary
- tested the package locally and the result is the same
- This also results in the possibility of removing the devDep `copyfiles`, but I left it up to you.

- Changes
- remove src/rxjs-operators/package.json
- remove first part of build:copy script