### PR TITLE
Fix a bunch of docstring typos

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -59,7 +59,7 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * Maps an `Option<T>` to `Option<U>` by either converting `T` to `U` using `mapper` (in case
      * of `Some`) or using the `default_` value (in case of `None`).
      *
-     * If `default` is a result of a function call consider using `mapOrElse` instead, it will
+     * If `default` is a result of a function call consider using `mapOrElse()` instead, it will
      * only evaluate the function when needed.
      */
     mapOr<U>(default_: U, mapper: (val: T) => U): U;
@@ -74,7 +74,7 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * Returns `Some()` if we have a value, otherwise returns `other`.
      * 
      * `other` is evaluated eagerly. If `other` is a result of a function
-     * call try `or_else()` instead – it evaluates the parameter lazily.
+     * call try `orElse()` instead – it evaluates the parameter lazily.
      * 
      * @example
      * 

--- a/src/result.ts
+++ b/src/result.ts
@@ -126,7 +126,7 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      * Returns `Ok()` if we have a value, otherwise returns `other`.
      * 
      * `other` is evaluated eagerly. If `other` is a result of a function
-     * call try `or_else()` instead – it evaluates the parameter lazily.
+     * call try `orElse()` instead – it evaluates the parameter lazily.
      * 
      * @example
      * 
@@ -136,7 +136,7 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     or<E2>(other: Result<T, E2>): Result<T, E2>
 
     /**
-     * Returns `Some()` if we have a value, otherwise returns the result
+     * Returns `Ok()` if we have a value, otherwise returns the result
      * of calling `other()`.
      * 
      * `other()` is called *only* when needed and is passed the error value in a parameter.


### PR DESCRIPTION
These were either incorrect or inconsistent with the rest of the documentation.