### PR TITLE
Take a first stab at async results

### DIFF
--- a/docs/reference/api/asyncresult.rst
+++ b/docs/reference/api/asyncresult.rst
@@ -1,0 +1,100 @@
+AsyncResult
+===========
+
+An async-aware :doc:`result` counterpart.
+
+Can be combined with asynchronous code without having to ``await`` anything right until
+the moment when you're ready to extract the final ``Result`` out of it.
+
+Can also be combined with synchronous code for convenience.
+
+.. code-block:: typescript
+
+    // T is the Ok value type, E is the Err error type
+    AsyncResult<T, E>
+
+Imports:
+
+.. code-block:: typescript
+
+    import { AsyncResult } from 'ts-results-es'
+
+Construction:
+
+You can construct it directly from ``Result<T, E>`` or ``Promise<Result<T, E>>``:
+
+.. code-block:: typescript
+
+    const result1 = new AsyncResult(Ok(1))
+    const result2 = new AsyncResult((async () => Err('bad_error')())
+
+Or you can use the :ref:`Result.toAsyncResult() <toAsyncResult>` method:
+
+.. code-block:: typescript
+
+    const result3 = Ok(1).toAsyncResult()
+
+Only the most important methods are currently implemented. The following methods can be
+added with not too much effort:
+
+* ``mapErr()``
+* ``mapOr()``
+* ``mapOrElse()``
+* ``or()``
+* ``orElse()``
+
+``andThen()``
+-------------
+
+.. code-block:: typescript
+
+    andThen<T2, E2>(
+        mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>
+    ): AsyncResult<T | T2, E | E2>
+
+Calls ``mapper`` if the result is ``Ok``, otherwise keeps the ``Err`` value intact.
+This function can be used for control flow based on ``Result`` values.
+
+Example:
+
+.. code-block:: typescript
+
+    let goodResult = Ok(1).toAsyncResult()
+    let badResult = Err('boo').toAsyncResult()
+
+    await goodResult.andThen(async (value) => Ok(value * 2)).promise // Ok(2)
+    await goodResult.andThen(async (value) => Err(`${value} is bad`)).promise // Err('1 is bad')
+    await badResult.andThen(async (value) => Ok(value * 2)).promise // Err('boo')
+
+``map()``
+---------
+
+.. code-block:: typescript
+
+    map<U>(mapper: (val: T) => U | Promise<U>): AsyncResult<U, E>
+
+Maps an ``AsyncResult<T, E>`` to ``AsyncResult<U, E>`` by applying a function to a contained
+``Ok`` value, leaving an ``Err`` value untouched.
+
+This function can be used to compose the results of two functions.
+
+Example:
+
+.. code-block:: typescript
+
+    let goodResult = Ok(1).toAsyncResult()
+    let badResult = Err('boo').toAsyncResult()
+
+    await goodResult.map(async (value) => value * 2).promise // Ok(2)
+    await badResult.andThen(async (value) => value * 2).promise // Err('boo')
+
+``promise``
+-----------
+
+.. code-block:: typescript
+
+    promise: Promise<Result<T, E>>
+
+A promise that resolves to a synchronous result.
+
+Await it to convert ``AsyncResult<T, E>`` to ``Result<T, E>``.

--- a/docs/reference/api/asyncresult.rst
+++ b/docs/reference/api/asyncresult.rst
@@ -50,7 +50,7 @@ added with not too much effort:
 
     andThen<T2, E2>(
         mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>
-    ): AsyncResult<T | T2, E | E2>
+    ): AsyncResult<T2, E | E2>
 
 Calls ``mapper`` if the result is ``Ok``, otherwise keeps the ``Err`` value intact.
 This function can be used for control flow based on ``Result`` values.

--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -4,6 +4,7 @@ API reference
 :doc:`option` documents ``None``, ``Option`` and ``Some``.
 :doc:`result` documents ``Err``, ``Ok`` and ``Result``.
 :doc:`rxjs` documents integration with `Reactive Extensions for JavaScript`_.
+:doc:`asyncresult` documents an async-aware ``Result`` (``AsyncResult``).
 
 .. toctree::
     :maxdepth: 1
@@ -11,6 +12,7 @@ API reference
 
     option
     result
+    asyncresult
     rxjs
 
 .. _Reactive Extensions for JavaScript: https://rxjs.dev/

--- a/docs/reference/api/result.rst
+++ b/docs/reference/api/result.rst
@@ -21,6 +21,9 @@ Construction:
     const success = Ok('my username')
     const error = Err('error_code')
 
+``Result`` can only be combined with synchronous code. Look at :doc:`asyncresult` if you need
+to combine results with asynchronouse code.
+
 ``all()``
 ---------
 
@@ -316,6 +319,20 @@ A stack trace is generated when an ``Err`` is created.
 
     let error = Err('Uh Oh');
     let stack = error.stack;
+
+.. _toAsyncResult:
+
+``toAsyncResult()``
+-------------------
+
+.. code-block:: typescript
+
+    toAsyncResult(): AsyncResult<T, E>
+
+Creates an `AsyncResult` based on this `Result`.
+
+Useful when you need to compose results with asynchronous code.
+
 
 ``toOption()``
 --------------

--- a/src/asyncresult.ts
+++ b/src/asyncresult.ts
@@ -1,0 +1,127 @@
+import { Err, Result, Ok } from './result.js'
+
+/**
+ * An async-aware `Result` counterpart.
+ *
+ * Can be combined with asynchronous code without having to ``await`` anything right until
+ * the moment when you're ready to extract the final ``Result`` out of it.
+ *
+ * Can also be combined with synchronous code for convenience.
+ */
+export class AsyncResult<T, E> {
+    /**
+     * A promise that resolves to a synchronous result.
+     *
+     * Await it to convert `AsyncResult<T, E>` to `Result<T, E>`.
+     */
+    promise: Promise<Result<T, E>>
+
+    /**
+     * Constructs an `AsyncResult` from a `Result` or a `Promise` of a `Result`.
+     *
+     * @example
+     * ```typescript
+     * const ar = new AsyncResult(Promise.resolve('value'))
+     * ```
+     */
+    constructor(start: Result<T, E> | Promise<Result<T, E>>) {
+        this.promise = Promise.resolve(start)
+    }
+
+    /**
+     * Calls `mapper` if the result is `Ok`, otherwise keeps the `Err` value intact.
+     * This function can be used for control flow based on `Result` values.
+     *
+     * @example
+     * ```typescript
+     * let goodResult = Ok(1).toAsyncResult()
+     * let badResult = Err('boo').toAsyncResult()
+     *
+     * await goodResult.andThen(async (value) => Ok(value * 2)).promise // Ok(2)
+     * await goodResult.andThen(async (value) => Err(`${value} is bad`)).promise // Err('1 is bad')
+     * await badResult.andThen(async (value) => Ok(value * 2)).promise // Err('boo')
+     * ```
+     */
+    andThen<T2, E2>(mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>): AsyncResult<T | T2, E | E2> {
+        return this.thenInternal(async (result) => {
+            if (result.isErr()) {
+                // SAFETY: What we're returning here is Err<E>. That doesn't sit well with
+                // TypeScript for some reason, let's explicitly expand the type to what this
+                // function is supposed to return.
+                return result as Err<E | E2>
+            }
+            const mapped = mapper(result.value)
+            return mapped instanceof AsyncResult ? mapped.promise : mapped
+        })
+    }
+
+    /**
+     * Maps an `AsyncResult<T, E>` to `AsyncResult<U, E>` by applying a function to a contained
+     * `Ok` value, leaving an `Err` value untouched.
+     *
+     * This function can be used to compose the results of two functions.
+     *
+     * @example
+     * ```typescript
+     * let goodResult = Ok(1).toAsyncResult()
+     * let badResult = Err('boo').toAsyncResult()
+     *
+     * await goodResult.map(async (value) => value * 2).promise // Ok(2)
+     * await badResult.andThen(async (value) => value * 2).promise // Err('boo')
+     * ```
+     */
+    map<U>(mapper: (val: T) => U | Promise<U>): AsyncResult<U, E> {
+        return this.thenInternal(async (result) => {
+            if (result.isErr()) {
+                return result
+            }
+            return Ok(await mapper(result.value))
+        })
+    }
+
+    // TODO:
+    // mapErr()
+    // mapOr()
+    // mapOrElse()
+    // or()
+    // orElse()
+
+    // mapErr<F>(mapper: (val: E) => F | Promise<F>): AsyncResult<T, F> {
+    //     return this.thenInternal(async (result) => {
+    //         if (result.isOk()) {
+    //             return result
+    //         }
+    //         return Err(await mapper(result.error))
+    //     })
+    // }
+
+    // async mapOr<U>(default_: U, mapper: (val: T) => U | Promise<U>): Promise<U> {
+    //     return this.mapOrElse(() => default_, mapper)
+    // }
+
+    // async mapOrElse<U>(default_: (error: E) => U | Promise<U>, mapper: (val: T) => U | Promise<U>): Promise<U> {
+    //     const result = await this.promise
+    //     if (result.isErr()) {
+    //         return default_(result.error)
+    //     }
+    //     return mapper(result.value)
+    // }
+
+    // or<E2>(other: Result<T, E2> | AsyncResult<T, E2> | Promise<Result<T, E2>>): AsyncResult<T, E2> {
+    //     return this.orElse(() => other)
+    // }
+
+    // orElse<E2>(other: (error: E) => Result<T, E2> | AsyncResult<T, E2> | Promise<Result<T, E2>>): AsyncResult<T, E2> {
+    //     return this.thenInternal(async (result) => {
+    //         if (result.isOk()) {
+    //             return result
+    //         }
+    //         const otherValue = other(result.error)
+    //         return otherValue instanceof AsyncResult ? otherValue.promise : otherValue
+    //     })
+    // }
+
+    private thenInternal<T2, E2>(mapper: (result: Result<T, E>) => Promise<Result<T2, E2>>): AsyncResult<T2, E2> {
+        return new AsyncResult(this.promise.then(mapper))
+    }
+}

--- a/src/asyncresult.ts
+++ b/src/asyncresult.ts
@@ -42,7 +42,7 @@ export class AsyncResult<T, E> {
      * await badResult.andThen(async (value) => Ok(value * 2)).promise // Err('boo')
      * ```
      */
-    andThen<T2, E2>(mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>): AsyncResult<T | T2, E | E2> {
+    andThen<T2, E2>(mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>): AsyncResult<T2, E | E2> {
         return this.thenInternal(async (result) => {
             if (result.isErr()) {
                 // SAFETY: What we're returning here is Err<E>. That doesn't sit well with

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './asyncresult.js';
 export * from './result.js';
 export * from './option.js';

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,6 @@
 import { toString } from './utils.js';
 import { Option, None, Some } from './option.js';
+import { AsyncResult } from './asyncresult.js'
 
 /*
  * Missing Rust Result type methods:
@@ -154,6 +155,13 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      *  Similar to rust's `ok` method
      */
     toOption(): Option<T>;
+
+    /**
+     * Creates an `AsyncResult` based on this `Result`.
+     *
+     * Useful when you need to compose results with asynchronous code.
+     */
+    toAsyncResult(): AsyncResult<T, E>
 }
 
 /**
@@ -270,6 +278,10 @@ export class ErrImpl<E> implements BaseResult<never, E> {
 
     get stack(): string | undefined {
         return `${this}\n${this._stack}`;
+    }
+
+    toAsyncResult(): AsyncResult<never, E> {
+        return new AsyncResult(this)
     }
 }
 
@@ -397,6 +409,10 @@ export class OkImpl<T> implements BaseResult<T, never> {
 
     toString(): string {
         return `Ok(${toString(this.value)})`;
+    }
+
+    toAsyncResult(): AsyncResult<T, never> {
+        return new AsyncResult(this)
     }
 }
 

--- a/test/asyncresult.test.ts
+++ b/test/asyncresult.test.ts
@@ -1,0 +1,24 @@
+import {
+    AsyncResult,
+    Err,
+    Ok,
+} from '../src/index.js';
+
+test('andThen() should work', async () => {
+    const err = Err('error')
+    const badResult = new AsyncResult(err)
+    const goodResult = new AsyncResult(Ok(100))
+
+    expect(await badResult.andThen(() => {throw new Error('Should not be called')}).promise).toEqual(err)
+    expect(await goodResult.andThen((value) => Promise.resolve(Ok(value * 2))).promise).toEqual(Ok(200))
+    expect(await goodResult.andThen((value) => Ok(value * 3).toAsyncResult()).promise).toEqual(Ok(300))
+})
+
+test('map() should work', async () => {
+    const err = Err('error')
+    const badResult = new AsyncResult(err)
+    const goodResult = new AsyncResult(Ok(100))
+
+    expect(await badResult.map(() => {throw new Error('Should not be called')}).promise).toEqual(err)
+    expect(await goodResult.map((value) => Promise.resolve(value * 2)).promise).toEqual(Ok(200))
+})

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -255,3 +255,9 @@ test('or / orElse', () => {
     expect(Ok(1).or(Ok(2))).toEqual(Ok(1))
     expect(Ok(1).orElse((_error) => {throw new Error('Call unexpected')})).toEqual(Ok(1))
 })
+
+test('toAsyncResult()', async () => {
+    expect(await Ok(1).toAsyncResult().promise).toEqual(Ok(1))
+    const err = Err('error')
+    expect(await err.toAsyncResult().promise).toEqual(err)
+})


### PR DESCRIPTION
It's very common to see this pattern in our (Lune) code:

    const thing: Promise<Result<T, E>> = ...
    // Now we want to return an error if Err but if Ok we want to
    // process it further with asynchronous code, so first await it:
    const result = await thing

    // Then manualy branch on the variant:
    if (result.isErr()) {
        return result
    }

    // Only now we can process it:

    const anotherThing: Promise<Result<U, E>> = asyncFunction(result.value)

    // But wait! We want to process it with *another* function
    (asyncAnotherFunction).
    // That means another await/if/return/process block.
    // ...

This PR attempts to make this whole thing much better and now the following will be possible:

    return new AsyncResult(thing)
        .andThen(asyncFunction)
        .andThen(asyncAnotherFunction)

* Why a separate type? Because I didn't find a way to fit promises/asynchronous mappers in the existing API in a way that provides static type safety and works correctly at runtime.
* Why only AsyncResult and not AsyncOption? Both makes sense but AsyncResult is the biggest bang for the buck for us.
* Why only the two methods (andThen and map)? We need these the most, the rest can be added later (when/if we decide we need them).
* Why not add async versions of the methods directly to Result (asyncMap, asyncAndThen etc.)? I decided it would result in too much duplication.
* Why allow synchronous functions to be composed with AsyncResult? For convenience – once you're in the AsyncResult realm it'll be the easiests to just stay in it and compose as many things as possible before finally converting back to Result.

I already implemented more methods so I kept the implementations commented out just so
we don't have to do the same work again.

Part-of: https://linear.app/lune/issue/LUN-2855/add-async-support-to-ts-results-es