### PR TITLE
Release version 4.1.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Not released yet
+# 4.1.0-alpha.1
 
 - A whole bunch of documentation changes
 - Introduced `AsyncResult` to allow composing results with asynchronous code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-results-es",
-  "version": "4.0.0",
+  "version": "4.1.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-results-es",
-      "version": "4.0.0",
+      "version": "4.1.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-results-es",
-  "version": "4.0.0",
+  "version": "4.1.0-alpha.1",
   "description": "A typescript implementation of Rust's Result and Option objects.",
   "scripts": {
     "build": "npm run clean && npm run build:ts && npm run build:copy",


### PR DESCRIPTION
We want to experiment with the recently added AsyncResult to see if it meets expectations.

A release explicitly marked as alpha so it's clear things can still change.