### PR TITLE
Allow commonjs bundle from esm source

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
-    },
-    "./rxjs-operators": {
-      "require": "./dist/cjs/rxjs-operators/index.js",
-      "import": "./dist/esm/rxjs-operators/index.js"
-    }
+      ".": {
+          "require": "./dist/cjs/index.js",
+          "import": "./dist/esm/index.js"
+      },
+      "./rxjs-operators": {
+        "require": "./dist/cjs/rxjs-operators/index.js",
+        "import": "./dist/esm/rxjs-operators/index.js"
+      }
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
-      ".": {
-          "import": "./dist/esm/index.js",
-          "require": "./dist/cjs/index.js"
-      },
-      "./rxjs-operators": {
-        "import": "./dist/esm/rxjs-operators/index.js",
-        "require": "./dist/cjs/rxjs-operators/index.js"
-      }
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    },
+    "./rxjs-operators": {
+      "require": "./dist/cjs/rxjs-operators/index.js",
+      "import": "./dist/esm/rxjs-operators/index.js"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello!

Thank you for your fork and active maintenance!

My main motivation for using `ts-results-es` over `ts-results` is compatibility with `esbuild`: after running into the problem noted in [this issue](https://github.com/vultix/ts-results/issues/37) and then reading that discussion, I decided to try to use `ts-results-es`.

However, `ts-results-es` did not work out of the box in my bundling setup. I need to produce a commonjs module (for compatibility with legacy dependencies) from typescript/esm source, but `esbuild --bundle --platform=node --conditions=require` was producing a bundle that imported from `ts-results-es/dist/esm` instead of `ts-results-es/dist/cjs`.

After some digging I determined that the issue is that `esbuild` checks `package.json.exports` in the order that the key-value pairs appear: [source code](https://github.com/evanw/esbuild/blob/main/internal/resolver/package_json.go#L1148), [confirmation from author](https://github.com/evanw/esbuild/issues/3166#issuecomment-1593434433).

Since `ts-results-es/package.json.exports` lists `import` before `require`, and both the `import` and `require` conditions are set since I am importing from `ts-results-es` with an `import` but also set `--conditions=require` via the command line, `import` is chosen over `require`. This PR swaps the order so that `require` is listed before `import`, so that `esbuild` chooses the `require` condition for my bundle.

Theoretically, this could break the setup of someone else who is importing `ts-results-es` using the legacy `require` syntax but is producing an `esm` bundle, but such a setup seems highly unlikely to me. My first thought is that it is much more likely that someone (like me) would want to use modern syntax (`import`) and produce a commonjs bundle for use with legacy packages or systems. I also [inquired on that thread](https://github.com/evanw/esbuild/issues/3166#issuecomment-1915984485) whether using legacy `require` syntax and bundling for `esm` is a legitimate or common use case.

I also fixed the inconsistent formatting in `package.json.exports` while I was in there.

Here is a stack blitz illustrating the problem and why my PR resolves it:
https://stackblitz.com/edit/node-kgd9vg?file=fixed%2Findex.ts,fixed%2Fpackage.json,fixed%2Fnode_modules%2Fts-results-es%2Fpackage.json,broken%2Findex.js,fixed%2Findex.js.
The only difference between the `broken` and `fixed` folders is the change I've introduced in this PR. Running `npm run build` in `broken` produces a bundle importing from `ts-results-es/dist/esm`, while running `npm run build` in `fixed` produces a bundle importing from `ts-results-es/dist/cjs`, as desired.