### PR TITLE
Implement AsyncResult or and orElse

### DIFF
--- a/docs/reference/api/asyncresult.rst
+++ b/docs/reference/api/asyncresult.rst
@@ -40,8 +40,6 @@ added with not too much effort:
 * ``mapErr()``
 * ``mapOr()``
 * ``mapOrElse()``
-* ``or()``
-* ``orElse()``
 
 ``andThen()``
 -------------
@@ -65,6 +63,55 @@ Example:
     await goodResult.andThen(async (value) => Ok(value * 2)).promise // Ok(2)
     await goodResult.andThen(async (value) => Err(`${value} is bad`)).promise // Err('1 is bad')
     await badResult.andThen(async (value) => Ok(value * 2)).promise // Err('boo')
+
+``or()``
+--------
+
+.. code-block:: typescript
+
+    or<E2>(other: Result<T, E2> | AsyncResult<T, E2> | Promise<Result<T, E2>>): AsyncResult<T, E2>
+
+Returns the value from ``other`` if this ``AsyncResult`` contains ``Err``, otherwise returns self.
+
+If ``other`` is a result of a function call consider using :ref:`AsyncResult.orElse` instead, it will
+only evaluate the function when needed.
+
+Example:
+
+.. code-block:: typescript
+
+    const badResult = new AsyncResult(Err('Error message'))
+    const goodResult = new AsyncResult(Ok(1))
+
+    await badResult.or(Ok(123)).promise // Ok(123)
+    await goodResult.or(Ok(123)).promise // Ok(1)
+
+
+.. _AsyncResult.orElse:
+
+``orElse()``
+------------
+
+.. code-block:: typescript
+
+    orElse<E2>(
+        other: (error: E) => Result<T, E2> | AsyncResult<T, E2> | Promise<Result<T, E2>>,
+    ): AsyncResult<T, E2>
+
+
+Returns the value obtained by calling ``other`` if this ``AsyncResult`` contains ``Err``, otherwise
+returns self.
+
+Example:
+
+.. code-block:: typescript
+
+    const badResult = new AsyncResult(Err('Error message'))
+    const goodResult = new AsyncResult(Ok(1))
+
+    await badResult.orElse(() => Ok(123)).promise // Ok(123)
+    await goodResult.orElse(() => Ok(123)).promise // Ok(1)
+
 
 ``map()``
 ---------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.11",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
-      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -4912,9 +4912,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.5.11",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
-      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",

--- a/test/asyncresult.test.ts
+++ b/test/asyncresult.test.ts
@@ -22,3 +22,32 @@ test('map() should work', async () => {
     expect(await badResult.map(() => {throw new Error('Should not be called')}).promise).toEqual(err)
     expect(await goodResult.map((value) => Promise.resolve(value * 2)).promise).toEqual(Ok(200))
 })
+
+test('or() should work', async () => {
+    const err = Err('Boo')
+    const badResult = new AsyncResult(err)
+    const goodResult = new AsyncResult(Ok(100))
+
+    expect(await badResult.or(Ok(200)).promise).toEqual(Ok(200))
+    expect(await goodResult.or(Ok(200)).promise).toEqual(Ok(100))
+
+    expect(await badResult.or(new AsyncResult(Ok(200))).promise).toEqual(Ok(200))
+    expect(await goodResult.or(new AsyncResult(Ok(200))).promise).toEqual(Ok(100))
+
+    expect(await badResult.or(Promise.resolve(Ok(200))).promise).toEqual(Ok(200))
+    expect(await goodResult.or(Promise.resolve(Ok(200))).promise).toEqual(Ok(100))
+})
+
+test('orElse() should work', async () => {
+    const err = Err('Boo')
+    const badResult = new AsyncResult(err)
+    const goodResult = new AsyncResult(Ok(100))
+    function notExpectedToBeCalled(): never {
+        throw new Error('Not expected to be called')
+    }
+
+    expect(await goodResult.orElse(notExpectedToBeCalled).promise).toEqual(Ok(100))
+    expect(await badResult.orElse(() => Ok(200)).promise).toEqual(Ok(200))
+    expect(await badResult.orElse(() => new AsyncResult(Ok(200))).promise).toEqual(Ok(200))
+    expect(await badResult.orElse(() => Promise.resolve(Ok(200))).promise).toEqual(Ok(200))
+})


### PR DESCRIPTION
A follow up to [1].

Two more convenience composition methods in AsyncResults and I was missing recently.

The sync Result has them already (with different signatures, of course).

[1] 3f55d157c925 ("Take a first stab at async results (#87)")