### PR TITLE
Configure the documentation dependencies better

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,9 +1,5 @@
 [tool.poetry]
-name = "docs"
-version = "0.1.0"
-description = ""
-authors = ["Lune <eng@lune.co>"]
-readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
We use Poetry to manage Python dependencies.

It has a special mode of operation[1] for cases where one doesn't manage their own package (publishing etc.) but only uses Poetry for dependency management – which is exactly our use case.

This allows us to stop providing dummy metadata in pyproject.toml.

[1] https://python-poetry.org/docs/basic-usage/#operating-modes