### PR TITLE
Fix managing the docs Python virtualenv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,11 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry
-      # Tell poetry to not use a virtual environment – no need
-      - poetry config virtualenvs.create false
     post_install:
-      - cd docs && poetry install
+      # Virtualenv management per
+      # https://docs.readthedocs.io/en/latest/build-customization.html#install-dependencies-with-poetry
+      # https://github.com/python-poetry/poetry/issues/9025#issuecomment-1963073941
+      - cd docs && VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
It seems we've been relying on a Poetry bug (or at least on a buggy behavior)[1].

This made our documentation builds to stop working with Poetry 1.8[2]:

    Running Sphinx v7.2.6
    making output directory... done

    Traceback (most recent call last):
      File "/home/docs/checkouts/readthedocs.org/user_builds/ts-results-es/envs/109/lib/python3.11/site-packages/sphinx/cmd/build.py", line 293, in build_main
        app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/ts-results-es/envs/109/lib/python3.11/site-packages/sphinx/application.py", line 272, in __init__
        self._init_builder()
      File "/home/docs/checkouts/readthedocs.org/user_builds/ts-results-es/envs/109/lib/python3.11/site-packages/sphinx/application.py", line 342, in _init_builder
        self.builder.init()
      File "/home/docs/checkouts/readthedocs.org/user_builds/ts-results-es/envs/109/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 219, in init
        self.init_templates()
      File "/home/docs/checkouts/readthedocs.org/user_builds/ts-results-es/envs/109/lib/python3.11/site-packages/sphinx/builders/html/__init__.py", line 270, in init_templates
        self.theme = theme_factory.create(themename)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/ts-results-es/envs/109/lib/python3.11/site-packages/sphinx/theming.py", line 230, in create
        raise ThemeError(__('no theme named %r found (missing theme.conf?)') % name)
    sphinx.errors.ThemeError: no theme named 'sphinx_rtd_theme' found (missing theme.conf?)

    Theme error:
    no theme named 'sphinx_rtd_theme' found (missing theme.conf?)

[1] https://github.com/python-poetry/poetry/issues/9025
[2] https://readthedocs.org/projects/ts-results-es/builds/23635323/