### PR TITLE
Add a missing mapErr method signature to the documentation

### DIFF
--- a/docs/reference/api/asyncresult.rst
+++ b/docs/reference/api/asyncresult.rst
@@ -137,6 +137,10 @@ Example:
 ``mapErr()``
 ------------
 
+.. code-block:: typescript
+
+    mapErr<F>(mapper: (val: E) => F | Promise<F>): AsyncResult<T, F>
+
 Maps an ``AsyncResult<T, E>`` to ``AsyncResult<T, F>`` by applying ``mapper`` to the ``Err`` value, 
 leaving ``Ok`` value untouched.
 


### PR DESCRIPTION
I forgot to include it when I pushed [1].

[1] ea052ad51bce ("Implement AsyncResult.mapErr (#113)")