### PR TITLE
Remove a few no longer relevant comments

### DIFF
--- a/docs/reference/api/asyncresult.rst
+++ b/docs/reference/api/asyncresult.rst
@@ -34,11 +34,6 @@ Or you can use the :ref:`Result.toAsyncResult() <toAsyncResult>` method:
 
     const result3 = Ok(1).toAsyncResult()
 
-Only the most important methods are currently implemented. The following methods can be
-added with not too much effort:
-
-* ``mapOr()``
-* ``mapOrElse()``
 
 ``andThen()``
 -------------

--- a/src/asyncresult.ts
+++ b/src/asyncresult.ts
@@ -79,9 +79,6 @@ export class AsyncResult<T, E> {
         })
     }
 
-    // TODO:
-    // mapOr()
-    // mapOrElse()
 
     /**
      * Maps an `AsyncResult<T, E>` to `AsyncResult<T, F>` by applying `mapper` to the `Err` value, 
@@ -104,18 +101,6 @@ export class AsyncResult<T, E> {
             return Err(await mapper(result.error))
         })
     }
-
-    // async mapOr<U>(default_: U, mapper: (val: T) => U | Promise<U>): Promise<U> {
-    //     return this.mapOrElse(() => default_, mapper)
-    // }
-
-    // async mapOrElse<U>(default_: (error: E) => U | Promise<U>, mapper: (val: T) => U | Promise<U>): Promise<U> {
-    //     const result = await this.promise
-    //     if (result.isErr()) {
-    //         return default_(result.error)
-    //     }
-    //     return mapper(result.value)
-    // }
 
     /**
      * Returns the value from `other` if this `AsyncResult` contains `Err`, otherwise returns self.


### PR DESCRIPTION
When I started working on this code I was convinced we wanted async versions of mapOr and mapOrElse. I'm no longer particularly convinced of that.

Why?

The value of the various composition methods in AsyncResult comes from being able to attach multiple pieces of code to AsyncResult while staying in the AsyncResult territory.

As soon as we leave that territory by extracting the underlying value from AsyncResult (which mapOr() and mapOrElse() would do) we can no longer easily keep composing.

I'm not saying the methods are definitely useless, it's just that let's implement them if we actually find a use case.