### PR TITLE
Migrate tsconfig global

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,11 +2,6 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testRegex: '/test/.*.test.ts',
-    globals: {
-        'ts-jest': {
-            tsconfig: 'test/tsconfig.json',
-        },
-    },
     collectCoverageFrom: ['src/**/*.ts'],
     collectCoverage: true,
     coverageThreshold: {
@@ -16,6 +11,11 @@ module.exports = {
             lines: 100,
             statements: 100,
         },
+    },
+    transform: {
+        '^.*\.ts$': ['ts-jest', {
+            tsconfig: 'test/tsconfig.json'
+        }]
     },
     moduleNameMapper: {
       "^(.*)\\.js$": "$1"


### PR DESCRIPTION
This PR silences the warnings presented when you run the test suite:
```
> ts-results-es@4.1.0 test
> jest

ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
...
```