### PR TITLE
Add Result.partition feature

### DIFF
--- a/docs/reference/api/result.rst
+++ b/docs/reference/api/result.rst
@@ -352,7 +352,7 @@ Example:
 .. code-block:: typescript
 
     Ok(1).orElse(() => Ok(2)) // => Ok(1)
-    Err('error').orElse(() => Ok(2)) // => Ok(2)
+    Err('error').orElse(() => Ok(2)) // => Ok(2) 
 
 ``stack``
 ---------

--- a/docs/reference/api/result.rst
+++ b/docs/reference/api/result.rst
@@ -129,6 +129,24 @@ Example:
 
     let url = results.unwrap(); // At least one attempt gave us a successful url
 
+``partition()``
+---------------
+
+.. code-block:: typescript
+
+    // The actual signature is more complicated but this should be good enough.
+    static partition<T, E>(results: Result<T, E>[]): [T[], E[]]
+
+Partitions a set of ``Result``, separating the ``Ok`` and ``Err`` values.
+
+Example:
+
+.. code-block:: typescript
+
+    let results: Result<number, string>[] = [Ok(1), Err('error1'), Ok(2), Err('error2')];
+
+    let [numbers, errors] = Result.partition(results); // [ [1, 2], ['error1', 'error2'] ]
+
 ``error``
 ---------
 
@@ -334,7 +352,7 @@ Example:
 .. code-block:: typescript
 
     Ok(1).orElse(() => Ok(2)) // => Ok(1)
-    Err('error').orElse(() => Ok(2)) // => Ok(2) 
+    Err('error').orElse(() => Ok(2)) // => Ok(2)
 
 ``stack``
 ---------

--- a/src/result.ts
+++ b/src/result.ts
@@ -518,6 +518,19 @@ export namespace Result {
         }
     }
 
+    /**
+     * Partitions a set of results, separating the `Ok` and `Err` values.
+     */
+    export function partition<const T extends Result<any, any>[]>(results: T): [ResultOkTypes<T>, ResultErrTypes<T>] {
+        return results.reduce(
+            ([oks, errors], v) =>
+                v.isOk()
+                    ? [[...oks, v.value] as ResultOkTypes<T>, errors]
+                    : [oks, [...errors, v.error] as ResultErrTypes<T>],
+            [[], []] as [ResultOkTypes<T>, ResultErrTypes<T>],
+        );
+    }
+
     export function isResult<T = any, E = any>(val: unknown): val is Result<T, E> {
         return val instanceof Err || val instanceof Ok;
     }

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -234,6 +234,36 @@ test('Result.wrapAsync', async () => {
     eq<typeof c, Result<number, string>>(true);
 });
 
+test('Result.partition', async () => {
+    const ok0 = Ok(3);
+    const ok1 = new Ok(true);
+    const err0 = Err(Symbol());
+    const err1 = new Err(Error());
+
+    const all0 = Result.partition([]);
+    expect(all0).toEqual([[], []]);
+    eq<typeof all0, [[], []]>(true);
+
+    const all1 = Result.partition([ok0, ok1, err0, err1]);
+    expect(all1).toEqual([
+        [ok0.value, ok1.value],
+        [err0.error, err1.error],
+    ]);
+    eq<typeof all1, [[number, boolean, never, never], [never, never, symbol, Error]]>(true);
+
+    const all2 = Result.partition([ok0, ok1]);
+    expect(all2).toEqual([[ok0.value, ok1.value], []]);
+    eq<typeof all2, [[number, boolean], [never, never]]>(true);
+
+    const all3 = Result.partition([err0, err1]);
+    expect(all3).toEqual([[], [err0.error, err1.error]]);
+    eq<typeof all3, [[never, never], [symbol, Error]]>(true);
+
+    const all4 = Result.partition([1, 2, 3, 4].map((num) => Ok(num) as Result<number, Error>));
+    expect(all4).toEqual([[1, 2, 3, 4], []]);
+    eq<typeof all4, [number[], Error[]]>(true);
+});
+
 test('safeUnwrap', () => {
     const ok1 = new Ok(3).safeUnwrap();
     expect(ok1).toEqual(3);


### PR DESCRIPTION
Hello Again! I'm often finding myself adding this tool as a companion utility alongside ts-result, and figured I'd throw it up here to see if it might be accepted as a bundled tool. 

We can sometimes find ourselves in positions where we want to practice error tolerance, that is, proceeding through a function collecting errors as they occur, but continuing with items who've succeeded. I've always been a bit baffled that a library based upon two core items (`Ok` and `Error`), has no bundled utility to separate the two. 

I'm proposing the introduction of `Result.partition(results)` which will return a tuple of `[Ok[], Error[]]` used as 
```typescript
const [oks, errors] = Result.partition(results)
```

A example use case of this would be report generation:

```typescript
function createReport(userIds: Uuid[]): { succeeded: ReportItem, errors: (GetUserError | GenerateReportError)[] } {
  const getUsersByIdResults = Result.all(userIds.map(userId => getUserById(userId)))
  const [users, getUserErrors] = Result.partition(getUsersByIdResults)

  const userReportsResults = Result.all(users.map(user => generateReport(user)));
  const [reports, generateReportErrors] = Result.partition(userReportsResults);

  return {
    succeeded: reports,
    errors: [...getUserErrors, ...generateReportErrors]
  }
}
```