### PR TITLE
Move the package publishing documentation out of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,3 @@ if (optionalUrl.some) {
 
 See https://ts-results-es.readthedocs.io/en/latest/reference/api/index.html to see the API
 reference.
-
-## Publishing the package
-
-The package is published manually right now.
-
-Steps to publish:
-
-1. Bump the version in `package.json` and `src/package.json` as needed
-2. Update the CHANGELOG
-3. Commit to Git in a single commit and add a tag: `git tag -a vX.X.X` (the tag description can be
-   anything)
-4. `npm run build && npm publish`
-5. Push both the `master` branch and the new tag to GitHub

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,0 +1,13 @@
+Publishing the package
+======================
+
+The package is published manually right now.
+
+Steps to publish:
+
+1. Bump the version in ``package.json`` and ``src/package.json`` as needed
+2. Update the CHANGELOG
+3. Commit to Git in a single commit and add a tag: ``git tag -a vX.X.X`` (the tag description can be
+   anything)
+4. ```npm run build && npm publish```
+5. Push both the ``master`` branch and the new tag to GitHub

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,12 @@ The documentation will live here.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: User documentation:
 
    reference/index
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Developer documentation:
+
+   dev/index


### PR DESCRIPTION
Continuing the work started in [1] for easier documentation consumption and maintenance.

[1] 633ccad330e8 ("Set up an initial documentation structure (#81)")