### PR TITLE
Move the usage examples out of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,53 +49,6 @@ or
 $ yarn add ts-results-es
 ```
 
-## Example
-
-### Option Example
-
-Convert this:
-
-```typescript
-declare function getLoggedInUsername(): string | undefined;
-
-declare function getImageURLForUsername(username: string): string | undefined;
-
-function getLoggedInImageURL(): string | undefined {
-    const username = getLoggedInUsername();
-    if (!username) {
-        return undefined;
-    }
-
-    return getImageURLForUsername(username);
-}
-
-const stringUrl = getLoggedInImageURL();
-const optionalUrl = stringUrl ? new URL(stringUrl) : undefined;
-console.log(optionalUrl);
-```
-
-To this:
-
-```typescript
-import { Option, Some, None } from 'ts-results-es';
-
-declare function getLoggedInUsername(): Option<string>;
-
-declare function getImageForUsername(username: string): Option<string>;
-
-function getLoggedInImage(): Option<string> {
-    return getLoggedInUsername().andThen(getImageForUsername);
-}
-
-const optionalUrl = getLoggedInImage().map((url) => new URL(stringUrl));
-console.log(optionalUrl); // Some(URL('...'))
-
-// To extract the value, do this:
-if (optionalUrl.some) {
-    const url: URL = optionalUrl.value;
-}
-```
-
 ## Usage
 
 See https://ts-results-es.readthedocs.io/en/latest/reference/api/index.html to see the API

--- a/README.md
+++ b/README.md
@@ -51,51 +51,6 @@ $ yarn add ts-results-es
 
 ## Example
 
-### Result Example
-
-Convert this:
-
-```typescript
-import { existsSync, readFileSync } from 'fs';
-
-function readFile(path: string): string {
-    if (existsSync(path)) {
-        return readFileSync(path);
-    } else {
-        // Callers of readFile have no way of knowing the function can fail
-        throw new Error('invalid path');
-    }
-}
-
-// This line may fail unexpectedly without warnings from typescript
-const text = readFile('test.txt');
-```
-
-To this:
-
-```typescript
-import { existsSync, readFileSync } from 'fs';
-import { Ok, Err, Result } from 'ts-results-es';
-
-function readFile(path: string): Result<string, 'invalid path'> {
-    if (existsSync(path)) {
-        return new Ok(readFileSync(path)); // new is optional here
-    } else {
-        return new Err('invalid path'); // new is optional here
-    }
-}
-
-// Typescript now forces you to check whether you have a valid result at compile time.
-const result = readFile('test.txt');
-if (result.isOk()) {
-    // text contains the file's content
-    const text = result.value;
-} else {
-    // err equals 'invalid path'
-    const err = result.error;
-}
-```
-
 ### Option Example
 
 Convert this:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,4 +12,5 @@ The documentation will live here.
    :maxdepth: 2
    :caption: Contents:
 
+   tutorials/index
    reference/index

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,0 +1,6 @@
+Tutorials
+=========
+
+.. toctree::
+    option
+    result

--- a/docs/tutorials/option.rst
+++ b/docs/tutorials/option.rst
@@ -1,0 +1,45 @@
+Getting started with ``Option``
+===============================
+
+Convert this:
+
+.. code-block:: typescript
+
+    declare function getLoggedInUsername(): string | undefined;
+
+    declare function getImageURLForUsername(username: string): string | undefined;
+
+    function getLoggedInImageURL(): string | undefined {
+        const username = getLoggedInUsername();
+        if (!username) {
+            return undefined;
+        }
+
+        return getImageURLForUsername(username);
+    }
+
+    const stringUrl = getLoggedInImageURL();
+    const optionalUrl = stringUrl ? new URL(stringUrl) : undefined;
+    console.log(optionalUrl);
+
+To this:
+
+.. code-block:: typescript
+
+    import { Option, Some, None } from 'ts-results-es';
+
+    declare function getLoggedInUsername(): Option<string>;
+
+    declare function getImageForUsername(username: string): Option<string>;
+
+    function getLoggedInImage(): Option<string> {
+        return getLoggedInUsername().andThen(getImageForUsername);
+    }
+
+    const optionalUrl = getLoggedInImage().map((url) => new URL(stringUrl));
+    console.log(optionalUrl); // Some(URL('...'))
+
+    // To extract the value, do this:
+    if (optionalUrl.some) {
+        const url: URL = optionalUrl.value;
+    }

--- a/docs/tutorials/result.rst
+++ b/docs/tutorials/result.rst
@@ -1,0 +1,46 @@
+Getting started with ``Result``
+===============================
+
+Convert this:
+
+.. code-block:: typescript
+
+    import { existsSync, readFileSync } from 'fs';
+
+    function readFile(path: string): string {
+        if (existsSync(path)) {
+            return readFileSync(path);
+        } else {
+            // Callers of readFile have no way of knowing the function can fail
+            throw new Error('invalid path');
+        }
+    }
+
+    // This line may fail unexpectedly without warnings from typescript
+    const text = readFile('test.txt');
+
+
+To this:
+
+.. code-block:: typescript
+
+    import { existsSync, readFileSync } from 'fs';
+    import { Ok, Err, Result } from 'ts-results-es';
+
+    function readFile(path: string): Result<string, 'invalid path'> {
+        if (existsSync(path)) {
+            return new Ok(readFileSync(path)); // new is optional here
+        } else {
+            return new Err('invalid path'); // new is optional here
+        }
+    }
+
+    // Typescript now forces you to check whether you have a valid result at compile time.
+    const result = readFile('test.txt');
+    if (result.isOk()) {
+        // text contains the file's content
+        const text = result.value;
+    } else {
+        // err equals 'invalid path'
+        const err = result.error;
+    }


### PR DESCRIPTION
Following up the work started in [1].

If we squint a little these examples are tutorial-like, let's put them in the tutorials section.

Following the Diataxis framework[2] for structuring the documentation.

[1] 633ccad330e8 ("Set up an initial documentation structure (#81)")
[2] https://diataxis.fr/