### PR TITLE
Implement {Option,Result}.unwrapOrElse

### DIFF
--- a/docs/reference/api/option.rst
+++ b/docs/reference/api/option.rst
@@ -192,5 +192,26 @@ Throws if the value is ``None``.
 
 Returns the contained ``Some`` value or a provided default.
 
+``unwrapOrElse()``
+--------------
+
+.. code-block:: typescript
+
+    unwrapOrElse<T2>(f: () => T2): T | T2
+
+Returns the contained ``Some`` value or computes a value with a provided function.
+
+The function is at most one time, only if needed.
+
+Example:
+
+.. code-block:: typescript
+
+    Some('OK').unwrapOrElse(
+        () => { console.log('Called'); return 'UGH'; }
+    ) // => 'OK', nothing printed
+
+    None.unwrapOrElse(() => 'UGH') // => 'UGH'
+
 
 .. _cause: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

--- a/docs/reference/api/option.rst
+++ b/docs/reference/api/option.rst
@@ -193,7 +193,7 @@ Throws if the value is ``None``.
 Returns the contained ``Some`` value or a provided default.
 
 ``unwrapOrElse()``
---------------
+------------------
 
 .. code-block:: typescript
 

--- a/docs/reference/api/option.rst
+++ b/docs/reference/api/option.rst
@@ -201,7 +201,7 @@ Returns the contained ``Some`` value or a provided default.
 
 Returns the contained ``Some`` value or computes a value with a provided function.
 
-The function is at most one time, only if needed.
+The function is called at most one time, only if needed.
 
 Example:
 

--- a/docs/reference/api/result.rst
+++ b/docs/reference/api/result.rst
@@ -459,4 +459,26 @@ Example:
     goodResult.unwrapOr(5); // 1
     badResult.unwrapOr(5); // 5
 
+``unwrapOrElse()``
+------------------
+
+.. code-block:: typescript
+
+    unwrapOrElse<T2>(f: (error: E) => T2): T | T2
+
+Returns the contained ``Ok`` value or computes a value with a provided function.
+
+The function is at most one time, only if needed.
+
+Example:
+
+.. code-block:: typescript
+
+    Ok('OK').unwrapOrElse(
+        (error) => { console.log(`Called, got ${error}`); return 'UGH'; }
+    ) // => 'OK', nothing printed
+
+    Err('A03B').unwrapOrElse((error) => `UGH, got ${error}') // => 'UGH, got A03B'
+
+
 .. _cause: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

--- a/docs/reference/api/result.rst
+++ b/docs/reference/api/result.rst
@@ -468,7 +468,7 @@ Example:
 
 Returns the contained ``Ok`` value or computes a value with a provided function.
 
-The function is at most one time, only if needed.
+The function is called at most one time, only if needed.
 
 Example:
 
@@ -478,7 +478,7 @@ Example:
         (error) => { console.log(`Called, got ${error}`); return 'UGH'; }
     ) // => 'OK', nothing printed
 
-    Err('A03B').unwrapOrElse((error) => `UGH, got ${error}') // => 'UGH, got A03B'
+    Err('A03B').unwrapOrElse((error) => `UGH, got ${error}`) // => 'UGH, got A03B'
 
 
 .. _cause: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

--- a/src/option.ts
+++ b/src/option.ts
@@ -43,6 +43,22 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
     unwrapOr<T2>(val: T2): T | T2;
 
     /**
+     * Returns the contained `Some` value or computes a value with a provided function.
+     *
+     * The function is at most one time, only if needed.
+     *
+     * @example
+     * ```
+     * Some('OK').unwrapOrElse(
+     *     () => { console.log('Called'); return 'UGH'; }
+     * ) // => 'OK', nothing printed
+     *
+     * None.unwrapOrElse(() => 'UGH') // => 'UGH'
+     * ```
+     */
+    unwrapOrElse<T2>(f: () => T2): T | T2;
+
+    /**
      * Calls `mapper` if the Option is `Some`, otherwise returns `None`.
      * This function can be used for control flow based on `Option` values.
      */
@@ -132,6 +148,10 @@ class NoneImpl implements BaseOption<never> {
 
     unwrapOr<T2>(val: T2): T2 {
         return val;
+    }
+
+    unwrapOrElse<T2>(f: () => T2): T2 {
+        return f();
     }
 
     expect(msg: string): never {
@@ -224,6 +244,10 @@ class SomeImpl<T> implements BaseOption<T> {
     }
 
     unwrapOr(_val: unknown): T {
+        return this.value;
+    }
+
+    unwrapOrElse(_f: unknown): T {
         return this.value;
     }
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -45,7 +45,7 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
     /**
      * Returns the contained `Some` value or computes a value with a provided function.
      *
-     * The function is at most one time, only if needed.
+     * The function is called at most one time, only if needed.
      *
      * @example
      * ```

--- a/src/result.ts
+++ b/src/result.ts
@@ -7,7 +7,6 @@ import { AsyncResult } from './asyncresult.js';
  * pub fn contains<U>(&self, x: &U) -> bool
  * pub fn contains_err<F>(&self, f: &F) -> bool
  * pub fn and<U>(self, res: Result<U, E>) -> Result<U, E>
- * pub fn unwrap_or_else<F>(self, op: F) -> T
  * pub fn expect_err(self, msg: &str) -> E
  * pub fn unwrap_or_default(self) -> T
  */
@@ -81,6 +80,22 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      *  (This is the `unwrap_or` in rust)
      */
     unwrapOr<T2>(val: T2): T | T2;
+
+    /**
+     * Returns the contained `Ok` value or computes a value with a provided function.
+     *
+     * The function is at most one time, only if needed.
+     *
+     * @example
+     * ```
+     * Ok('OK').unwrapOrElse(
+     *     (error) => { console.log(`Called, got ${error}`); return 'UGH'; }
+     * ) // => 'OK', nothing printed
+     *
+     * Err('A03B').unwrapOrElse((error) => `UGH, got ${error}') // => 'UGH, got A03B'
+     * ```
+     */
+    unwrapOrElse<T2>(f: (error: E) => T2): T | T2;
 
     /**
      * Calls `mapper` if the result is `Ok`, otherwise returns the `Err` value of self.
@@ -218,6 +233,10 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         return val;
     }
 
+    unwrapOrElse<T2>(f: (error: E) => T2): T2 {
+        return f(this.error);
+    }
+
     expect(msg: string): never {
         // The cause casting required because of the current TS definition being overly restrictive
         // (the definition says it has to be an Error while it can be anything).
@@ -337,6 +356,10 @@ export class OkImpl<T> implements BaseResult<T, never> {
     }
 
     unwrapOr(_val: unknown): T {
+        return this.value;
+    }
+
+    unwrapOrElse(_f: unknown): T {
         return this.value;
     }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -84,7 +84,7 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     /**
      * Returns the contained `Ok` value or computes a value with a provided function.
      *
-     * The function is at most one time, only if needed.
+     * The function is called at most one time, only if needed.
      *
      * @example
      * ```
@@ -92,7 +92,7 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
      *     (error) => { console.log(`Called, got ${error}`); return 'UGH'; }
      * ) // => 'OK', nothing printed
      *
-     * Err('A03B').unwrapOrElse((error) => `UGH, got ${error}') // => 'UGH, got A03B'
+     * Err('A03B').unwrapOrElse((error) => `UGH, got ${error}`) // => 'UGH, got A03B'
      * ```
      */
     unwrapOrElse<T2>(f: (error: E) => T2): T | T2;

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -1,5 +1,5 @@
 import { Err, None, Ok, Option, OptionSomeType, Result, Some } from '../src/index.js';
-import { eq } from './util.js';
+import { eq, notSupposedToBeCalled } from './util.js';
 
 const someString = Some('foo');
 const someNum = new Some(10);
@@ -65,6 +65,11 @@ test('unwrap', () => {
     expect(() => None.unwrap()).toThrow(/Tried to unwrap None/);
     expect(() => None.expect('foobar')).toThrow(/foobar/);
     expect(None.unwrapOr('honk')).toBe('honk');
+});
+
+test('unwrapOrElse', () => {
+    expect(Some('1').unwrapOrElse(notSupposedToBeCalled)).toEqual('1');
+    expect(None.unwrapOrElse(() => '2')).toEqual('2');
 });
 
 test('map / andThen', () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -10,7 +10,7 @@ import {
     ResultOkTypes,
     Some,
 } from '../src/index.js';
-import { eq } from './util.js';
+import { eq, notSupposedToBeCalled } from './util.js';
 
 test('Err<E> | Ok<T> should be Result<T, E>', () => {
     const r1 = Err(0);
@@ -332,4 +332,9 @@ test('toAsyncResult()', async () => {
     expect(await Ok(1).toAsyncResult().promise).toEqual(Ok(1));
     const err = Err('error');
     expect(await err.toAsyncResult().promise).toEqual(err);
+});
+
+test('unwrapOrElse', () => {
+    expect(Ok({ data: 'user data' }).unwrapOrElse(notSupposedToBeCalled)).toEqual({ data: 'user data' });
+    expect(Err('bad error').unwrapOrElse((error) => ({ error }))).toEqual({ error: 'bad error' });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -94,3 +94,7 @@ expect.extend({
         };
     },
 });
+
+export function notSupposedToBeCalled() {
+    throw new Error('This is not supposed to be called');
+}


### PR DESCRIPTION
Something I re-discovered as missing yesterday, we can definitely use this in some places.

The equivalent of Rust's unwrap_or_else.