### PR TITLE
Correct signature for Result.partition

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -545,7 +545,7 @@ export namespace Result {
     /**
      * Partitions a set of results, separating the `Ok` and `Err` values.
      */
-    export function partition<const T extends Result<any, any>[]>(results: T): [ResultOkTypes<T>, ResultErrTypes<T>] {
+    export function partition<T extends Result<any, any>[]>(results: T): [ResultOkTypes<T>, ResultErrTypes<T>] {
         return results.reduce(
             ([oks, errors], v) =>
                 v.isOk()

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -239,29 +239,35 @@ test('Result.partition', async () => {
     const ok1 = new Ok(true);
     const err0 = Err(Symbol());
     const err1 = new Err(Error());
+    const result0 = Ok(3) as unknown as Result<number, symbol>;
+    const result1 = new Ok(true) as unknown as Result<boolean, Error>;
 
     const all0 = Result.partition([]);
     expect(all0).toEqual([[], []]);
-    eq<typeof all0, [[], []]>(true);
+    eq<typeof all0, [never[], never[]]>(true);
 
     const all1 = Result.partition([ok0, ok1, err0, err1]);
     expect(all1).toEqual([
         [ok0.value, ok1.value],
         [err0.error, err1.error],
     ]);
-    eq<typeof all1, [[number, boolean, never, never], [never, never, symbol, Error]]>(true);
+    eq<typeof all1, [(number | boolean)[], (symbol | Error)[]]>(true);
 
     const all2 = Result.partition([ok0, ok1]);
     expect(all2).toEqual([[ok0.value, ok1.value], []]);
-    eq<typeof all2, [[number, boolean], [never, never]]>(true);
+    eq<typeof all2, [(number | boolean)[], never[]]>(true);
 
     const all3 = Result.partition([err0, err1]);
     expect(all3).toEqual([[], [err0.error, err1.error]]);
-    eq<typeof all3, [[never, never], [symbol, Error]]>(true);
+    eq<typeof all3, [never[], (symbol | Error)[]]>(true);
 
     const all4 = Result.partition([1, 2, 3, 4].map((num) => Ok(num) as Result<number, Error>));
     expect(all4).toEqual([[1, 2, 3, 4], []]);
     eq<typeof all4, [number[], Error[]]>(true);
+
+    const all5 = Result.partition([result0, result1]);
+    expect(all5).toEqual([[(result0 as Ok<number>).value, (result1 as Ok<boolean>).value], []]);
+    eq<typeof all5, [(number | boolean)[], (symbol | Error)[]]>(true);
 });
 
 test('safeUnwrap', () => {


### PR DESCRIPTION
Hello @jstasiak! I must confess, I hadn't been able to update to the latest version of ts-results-es until recently. I had a shower thought last night that the signature for Result.partition was actually incorrect. 

```Typescript
const all1 = Result.partition([ok0, ok1, err0, err1]);
expect(all1).toEqual([
    [ok0.value, ok1.value],
    [err0.error, err1.error],
]);
eq<typeof all1, [[number, boolean, never, never], [never, never, symbol, Error]]>(true);
```

The signature above implies that `all` is equal to `[[number, boolean, undefined, undefined], [undefined, undefined, symbol, Error]]` but this is not how that function works. Successes and errors will be pushed onto the partition array as they come, and we can't guarantee what index the successes or errors will be at. The real result from that function would be `[[number, boolean], [symbol, Error]]`

I've updated the signature and tests to reflect this. Could we patch this in? Very sorry for the inconvenience. 