### PR TITLE
Change the approach to Option and Result iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 5.0.0 (not released yet)
+
+Backwards incompatible:
+
+- Changed `Option` and `Result` iterator behavior such that iterating `Some` and `Ok` will
+  instead produce only one result – the wrapped value. Previously the iteration depended on
+  the type of the wrapped value (iteratable or not) and produced results obtained by iterating
+  the wrapped values.
+
+  For example:
+
+  ```
+  const o: Option<number[]> = Some([1, 2, 3])
+  const rs = Array.from(o)
+  // Previously: rs was [1, 2, 3]
+  // Now: rs equals [[1, 2, 3]]
+  ```
+
+  Iterating `None` and `Err` is not affected and continues to produce no results.
+
 # 4.2.0
 
 Added:

--- a/src/option.ts
+++ b/src/option.ts
@@ -2,7 +2,7 @@ import { AsyncOption } from './asyncoption.js';
 import { toString } from './utils.js';
 import { Result, Ok, Err } from './result.js';
 
-interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never> {
+interface BaseOption<T> extends Iterable<T> {
     /** `true` when the Option is Some */
     isSome(): this is SomeImpl<T>;
 
@@ -220,19 +220,8 @@ class SomeImpl<T> implements BaseOption<T> {
 
     readonly value!: T;
 
-    /**
-     * Helper function if you know you have an Some<T> and T is iterable
-     */
-    [Symbol.iterator](): Iterator<T extends Iterable<infer U> ? U : never> {
-        const obj = Object(this.value) as Iterable<any>;
-
-        return Symbol.iterator in obj
-            ? obj[Symbol.iterator]()
-            : {
-                  next(): IteratorResult<never, never> {
-                      return { done: true, value: undefined! };
-                  },
-              };
+    [Symbol.iterator](): Iterator<T> {
+        return [this.value][Symbol.iterator]();
     }
 
     constructor(val: T) {

--- a/src/result.ts
+++ b/src/result.ts
@@ -10,7 +10,7 @@ import { AsyncResult } from './asyncresult.js';
  * pub fn expect_err(self, msg: &str) -> E
  * pub fn unwrap_or_default(self) -> T
  */
-interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : never> {
+interface BaseResult<T, E> extends Iterable<T> {
     /** `true` when the result is Ok */
     isOk(): this is OkImpl<T>;
 
@@ -325,19 +325,8 @@ export class OkImpl<T> implements BaseResult<T, never> {
 
     readonly value!: T;
 
-    /**
-     * Helper function if you know you have an Ok<T> and T is iterable
-     */
-    [Symbol.iterator](): Iterator<T extends Iterable<infer U> ? U : never> {
-        const obj = Object(this.value) as Iterable<any>;
-
-        return Symbol.iterator in obj
-            ? obj[Symbol.iterator]()
-            : {
-                  next(): IteratorResult<never, never> {
-                      return { done: true, value: undefined! };
-                  },
-              };
+    [Symbol.iterator](): Iterator<T> {
+        return [this.value][Symbol.iterator]();
     }
 
     constructor(val: T) {

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -114,7 +114,6 @@ test('mapOr / mapOrElse', () => {
 });
 
 test('iterable', () => {
-    const values = Array.from(Ok('hello'));
     expect(Array.from(Ok('hello'))).toEqual(['hello']);
     expect(Array.from(Ok([1, 2, 3]))).toEqual([[1, 2, 3]]);
     expect(Array.from(Ok(1))).toEqual([1]);

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -114,25 +114,10 @@ test('mapOr / mapOrElse', () => {
 });
 
 test('iterable', () => {
-    let i = 0;
-    for (const char of Ok('hello')) {
-        expect('hello'[i]).toBe(char);
-        expect_string(char, true);
-        i++;
-    }
-
-    i = 0;
-    for (const item of Ok([1, 2, 3])) {
-        expect([1, 2, 3][i]).toBe(item);
-        eq<number, typeof item>(true);
-        i++;
-    }
-
-    for (const item of Ok(1)) {
-        expect_never(item, true);
-
-        throw new Error('Unreachable, Err@@iterator should emit no value and return');
-    }
+    const values = Array.from(Ok('hello'));
+    expect(Array.from(Ok('hello'))).toEqual(['hello']);
+    expect(Array.from(Ok([1, 2, 3]))).toEqual([[1, 2, 3]]);
+    expect(Array.from(Ok(1))).toEqual([1]);
 });
 
 test('to string', () => {

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -167,3 +167,11 @@ test('toAsyncOption()', async () => {
     expect(await Some(1).toAsyncOption().promise).toEqual(Some(1));
     expect(await None.toAsyncOption().promise).toEqual(None);
 });
+
+test('iteration', () => {
+    const iterator = (Some(1) as Option<number>)[Symbol.iterator]();
+    eq<Iterator<number>, typeof iterator>(true);
+
+    expect(Array.from(Some(1))).toEqual([1]);
+    expect(Array.from(None)).toEqual([]);
+});

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -61,11 +61,11 @@ test('mapErr', () => {
 test('Iterable', () => {
     const r1 = new Ok([true, false]) as Result<boolean[], number>;
     const r1Iter = r1[Symbol.iterator]();
-    eq<Iterator<boolean>, typeof r1Iter>(true);
+    eq<Iterator<boolean[]>, typeof r1Iter>(true);
 
     const r2 = new Ok(32) as Result<number, string>;
     const r2Iter = r2[Symbol.iterator]();
-    eq<Iterator<never>, typeof r2Iter>(true);
+    eq<Iterator<number>, typeof r2Iter>(true);
 });
 
 test('ResultOkType', () => {


### PR DESCRIPTION
Previously iterating Some and Ok objects depended on whether the underlying type T was iterable or not.

If it was the results of the iteration were obtained by iterating the underlying value. There could be an arbitrary number of results.

For example this was the case *before* (using Some to demonstrate the idea, the same applies to Ok):

    // Some<number>, no results because 1 is not iterable
    for (const e of Some(1)) { ... }
    // Some<number[]>, two results produced
    for (const e of Some([1, 2])) { ... }
    // Some<number[]>, no results produced because the underlying value
    // contains no items
    for (const e of Some([]) as Option<number[]>) { ... }

This mode of operation never quite worked for me because:

1. It depended on the underlying value being iterable and didn't provide any value in case of numbers, strings and other non-iterable values.
2. It made it impossible to use iteration of Option and Result values to conditionally run some code only when dealing with Some and Ok instances.

This patch tackles both of these issues at once (they're connected).

The change brings the iteration behavior in line with how Rust's Option and Result do things[1] (zero-or-one iteration resuls, never multiple results).

If one needs the old behavior it can be achieved with a little bit of additional code, it's not the case in the opposite direction. For example:

    const ids: Option<number[]> = ...

    // Previously:
    for (const id of ids) { ... }
    // Now (one of potential solutions):
    for (const id of ids.unwrapOr([])) { ... }

[1] https://doc.rust-lang.org/std/option/enum.Option.html#method.iter