### PR TITLE
Fix not being able to call Result's or and orElse methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Backwards incompatible:
 
   Iterating `None` and `Err` is not affected and continues to produce no results.
 
+Fixed:
+
+- Fixed `Result.or` and `Result.orElse` method types to actually be callable and return
+  reasonable types when called.
+
 # 4.2.0
 
 Added:

--- a/src/result.ts
+++ b/src/result.ts
@@ -280,14 +280,14 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         return default_(this.error);
     }
 
-    or<T>(other: Ok<T>): Result<T, never>
-    or<R extends Result<any, any>>(other: R): R
+    or<T>(other: Ok<T>): Result<T, never>;
+    or<R extends Result<any, any>>(other: R): R;
     or<T, E2>(other: Result<T, E2>): Result<T, E2> {
         return other;
     }
 
-    orElse<T>(other: (error: E) => Ok<T>): Result<T, never>
-    orElse<R extends Result<any, any>>(other: (error: E) => R): R
+    orElse<T>(other: (error: E) => Ok<T>): Result<T, never>;
+    orElse<R extends Result<any, any>>(other: (error: E) => R): R;
     orElse<T, E2>(other: (error: E) => Result<T, E2>): Result<T, E2> {
         return other(this.error);
     }

--- a/src/result.ts
+++ b/src/result.ts
@@ -280,10 +280,14 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         return default_(this.error);
     }
 
+    or<T>(other: Ok<T>): Result<T, never>
+    or<R extends Result<any, any>>(other: R): R
     or<T, E2>(other: Result<T, E2>): Result<T, E2> {
         return other;
     }
 
+    orElse<T>(other: (error: E) => Ok<T>): Result<T, never>
+    orElse<R extends Result<any, any>>(other: (error: E) => R): R
     orElse<T, E2>(other: (error: E) => Result<T, E2>): Result<T, E2> {
         return other(this.error);
     }
@@ -395,11 +399,11 @@ export class OkImpl<T> implements BaseResult<T, never> {
         return mapper(this.value);
     }
 
-    or<E2>(_other: Result<T, E2>): Result<T, E2> {
+    or(_other: Result<T, any>): Ok<T> {
         return this;
     }
 
-    orElse<E2>(_other: (error: never) => Result<T, E2>): Result<T, E2> {
+    orElse(_other: (error: never) => Result<T, any>): Ok<T> {
         return this;
     }
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -323,21 +323,21 @@ test('To option', () => {
 });
 
 test('or / orElse', () => {
-    const result = Err('boo') as Result<number, string>
+    const result = Err('boo') as Result<number, string>;
 
-    const afterOrElseAlwaysErr = result.orElse((error) => Err(error === 'boo'))
-    eq<typeof afterOrElseAlwaysErr, Result<number, boolean>>(true)
-    const afterOrElseAlwaysOk = result.orElse((_error) => Ok(1))
-    eq<typeof afterOrElseAlwaysOk, Result<number, never>>(true)
-    const afterOrElseAnyResult = result.orElse((error) => error === 'foo' ? Ok(1) : Err('bar'))
-    eq<typeof afterOrElseAnyResult, Result<number, string>>(true)
+    const afterOrElseAlwaysErr = result.orElse((error) => Err(error === 'boo'));
+    eq<typeof afterOrElseAlwaysErr, Result<number, boolean>>(true);
+    const afterOrElseAlwaysOk = result.orElse((_error) => Ok(1));
+    eq<typeof afterOrElseAlwaysOk, Result<number, never>>(true);
+    const afterOrElseAnyResult = result.orElse((error) => (error === 'foo' ? Ok(1) : Err('bar')));
+    eq<typeof afterOrElseAnyResult, Result<number, string>>(true);
 
-    const afterOrErr = result.or(Err(true))
-    eq<typeof afterOrErr, Result<number, boolean>>(true)
-    const afterOrOk = result.or(Ok(1))
-    eq<typeof afterOrOk, Result<number, never>>(true)
-    const afterOrResult = result.or(Err(true) as Result<number, boolean>)
-    eq<typeof afterOrResult, Result<number, boolean>>(true)
+    const afterOrErr = result.or(Err(true));
+    eq<typeof afterOrErr, Result<number, boolean>>(true);
+    const afterOrOk = result.or(Ok(1));
+    eq<typeof afterOrOk, Result<number, never>>(true);
+    const afterOrResult = result.or(Err(true) as Result<number, boolean>);
+    eq<typeof afterOrResult, Result<number, boolean>>(true);
 
     expect(Err('error').or(Ok(1))).toEqual(Ok(1));
     expect(Err('error').orElse((error) => Ok(error.length))).toEqual(Ok(5));

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -323,6 +323,24 @@ test('To option', () => {
 });
 
 test('or / orElse', () => {
+    const result = Err('boo') as Result<number, string>
+
+    const afterOrElseAlwaysErr = result.orElse((error) => Err(error === 'boo'))
+    eq<typeof afterOrElseAlwaysErr, Result<number, boolean>>(true)
+    const afterOrElseAlwaysOk = result.orElse((_error) => Ok(1))
+    // Open question if we want never or string in the E position here
+    eq<typeof afterOrElseAlwaysOk, Result<number, never>>(true)
+    const afterOrElseAnyResult = result.orElse((error) => error === 'foo' ? Ok(1) : Err('bar'))
+    eq<typeof afterOrElseAnyResult, Result<number, string>>(true)
+
+    const afterOrErr = result.or(Err(true))
+    eq<typeof afterOrErr, Result<number, boolean>>(true)
+    const afterOrOk = result.or(Ok(1))
+    // Open question if we want never or string in the E position here
+    eq<typeof afterOrOk, Result<number, never>>(true)
+    const afterOrResult = result.or(Err(true) as Result<number, boolean>)
+    eq<typeof afterOrResult, Result<number, boolean>>(true)
+
     expect(Err('error').or(Ok(1))).toEqual(Ok(1));
     expect(Err('error').orElse((error) => Ok(error.length))).toEqual(Ok(5));
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -328,7 +328,6 @@ test('or / orElse', () => {
     const afterOrElseAlwaysErr = result.orElse((error) => Err(error === 'boo'))
     eq<typeof afterOrElseAlwaysErr, Result<number, boolean>>(true)
     const afterOrElseAlwaysOk = result.orElse((_error) => Ok(1))
-    // Open question if we want never or string in the E position here
     eq<typeof afterOrElseAlwaysOk, Result<number, never>>(true)
     const afterOrElseAnyResult = result.orElse((error) => error === 'foo' ? Ok(1) : Err('bar'))
     eq<typeof afterOrElseAnyResult, Result<number, string>>(true)
@@ -336,7 +335,6 @@ test('or / orElse', () => {
     const afterOrErr = result.or(Err(true))
     eq<typeof afterOrErr, Result<number, boolean>>(true)
     const afterOrOk = result.or(Ok(1))
-    // Open question if we want never or string in the E position here
     eq<typeof afterOrOk, Result<number, never>>(true)
     const afterOrResult = result.or(Err(true) as Result<number, boolean>)
     eq<typeof afterOrResult, Result<number, boolean>>(true)


### PR DESCRIPTION
The error solved here:

    test/result.test.ts:327:38 - error TS2349: This expression is not callable.
      Each member of the union type '(<R extends Result<number, unknown>>(_other: (error: never) => R) => OkImpl<number>) | (<R extends Result<unknown, unknown>>(other: (error: string) => R) => R)' has signatures, but none of those signatures are compatible with each other.

    327     const resultAfterOrElse = result.orElse((error) => Err(error))
                                             ~~~~~~
    test/result.test.ts:327:46 - error TS7006: Parameter 'error' implicitly has an 'any' type.

    327     const resultAfterOrElse = result.orElse((error) => Err(error))
                                                     ~~~~~

The same issue existed in both implementations and the fix is basically the same.

There are two aspects of this patch, one I'm pretty confident about and the other remains an open question:

1. Calling or() and orElse() should compile and work at runtime - this is prtty clear and it works.
2. What should the type be if we have enough information to help narrow the types?

To expand on the latter point, for example let's say we have

    const result: Result<number, string> = ...
    const final = result.or(Ok(1))

then the type of final could be, in principle, one of these:

a. Result<number, string>
b. Result<number, never>
c. Ok<number>

We know it's going to be Ok<number> but I'm not entirely sure it should be reflected in the type because I can totally see this kind of type narrowing resulting in losing precious type information in the client code where someone would like to maintain a Result<T, E> context and not have it narrowed down to Ok<T>.

I'm not very confident about that but that's my prediction.

Therefore I went with that expression evaluating to option b (Result<number, never>) to at least remain in the Result context and the implementation of this is simple enough.

Also I feel that the case where the "other" result is gonna be statically known to always be Ok is going to be an edge case we don't have to worry about.

If this proves to be a problem let's revisit the issue.

Resolves: https://github.com/lune-climate/ts-results-es/issues/175