### PR TITLE
Fix the AsyncResult.andThen handling of known-Ok transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Fixed:
 
 - Fixed `Result.or` and `Result.orElse` method types to actually be callable and return
   reasonable types when called.
+- Fixed `AsyncResult.andThen` to return the correct type when the provided callback
+  always returns an `Ok`.
 
 # 4.2.0
 

--- a/src/asyncresult.ts
+++ b/src/asyncresult.ts
@@ -43,6 +43,10 @@ export class AsyncResult<T, E> {
      * await badResult.andThen(async (value) => Ok(value * 2)).promise // Err('boo')
      * ```
      */
+    andThen<T2>(mapper: (val: T) => Ok<T2> | Promise<Ok<T2>> | AsyncResult<T2, never>): AsyncResult<T2, E>;
+    andThen<T2, E2>(
+        mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>,
+    ): AsyncResult<T2, E | E2>;
     andThen<T2, E2>(
         mapper: (val: T) => Result<T2, E2> | Promise<Result<T2, E2>> | AsyncResult<T2, E2>,
     ): AsyncResult<T2, E | E2> {

--- a/test/asyncresult.test.ts
+++ b/test/asyncresult.test.ts
@@ -1,5 +1,5 @@
-import { eq } from 'util.js';
 import { AsyncResult, Err, Ok, Result, Some } from '../src/index.js';
+import { eq } from './util.js';
 
 test('andThen() should work', async () => {
     const err = Err('error');

--- a/test/asyncresult.test.ts
+++ b/test/asyncresult.test.ts
@@ -1,9 +1,10 @@
-import { AsyncResult, Err, Ok, Some } from '../src/index.js';
+import { eq } from 'util.js';
+import { AsyncResult, Err, Ok, Result, Some } from '../src/index.js';
 
 test('andThen() should work', async () => {
     const err = Err('error');
     const badResult = new AsyncResult(err);
-    const goodResult = new AsyncResult(Ok(100));
+    const goodResult = new AsyncResult(Ok(100) as Result<number, string>);
 
     expect(
         await badResult.andThen(() => {
@@ -12,6 +13,11 @@ test('andThen() should work', async () => {
     ).toEqual(err);
     expect(await goodResult.andThen((value) => Promise.resolve(Ok(value * 2))).promise).toEqual(Ok(200));
     expect(await goodResult.andThen((value) => Ok(value * 3).toAsyncResult()).promise).toEqual(Ok(300));
+
+    const afterAndThenOk = goodResult.andThen((value) => Promise.resolve(Ok(value * 2)));
+    eq<typeof afterAndThenOk, AsyncResult<number, string>>(true);
+    const afterAndThenResult = goodResult.andThen(() => Ok(true) as Result<boolean, boolean>);
+    eq<typeof afterAndThenResult, AsyncResult<boolean, string | boolean>>(true);
 });
 
 test('map() should work', async () => {


### PR DESCRIPTION
Without these overloads

    goodResult.andThen((value) => Promise.resolve(Ok(value * 2)));

was of type

    AsyncResult<number, unknown>

which would cause downstream problems.

Granted, this could be an edge case and the map method could be better for this (Ok -> Ok transformation so only the value inside changes) but still, I don't think we should be generating unknown here, hence the patch.

Resolves: https://github.com/lune-climate/ts-results-es/issues/176