### PR TITLE
Fix a non-array Result.any call in the tests

### DIFF
--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -157,7 +157,7 @@ test('Result.any', () => {
     expect(any0).toMatchResult(Err([]));
     eq<typeof any0, Result<never, []>>(true);
 
-    const any0Array = Result.any();
+    const any0Array = Result.any([]);
     expect(any0Array).toMatchResult(Err([]));
     eq<typeof any0Array, Result<never, []>>(true);
 


### PR DESCRIPTION
This particular test is supposed to verify the handling of array parameters so we need to pass an array (although an empty one).