### PR TITLE
Upgrade CI Node from 17.x to 22.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [22.14.0]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
The 17.x branch is not a Long-Term Support branch and has been unsupported for a long time (last release in 2022[1]).

Let's upgrade to something more modern to make sure the CI process keeps working and the environment is more consistent with what's used to develop this package on our own machines.

Why 22.x instead of 23.x? 22 is an LTS line while the support for 23 will disappear more quickly[1].

Why specific version instead of 22.x? To avoid the exact version changing without our intervention and breaking things.

[1] https://nodejs.org/en/about/previous-releases