### PR TITLE
Upgrade seutp-node from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
I've seen some build failures like

    Run actions/setup-node@v2
    Found in cache @ /opt/hostedtoolcache/node/22.14.0/x64
    /opt/hostedtoolcache/node/22.14.0/x64/bin/npm config get cache
    /home/runner/.npm
    Error: Cache service responded with 422

which this upgrade will resolve (recommended in [2]).

[1] https://github.com/lune-climate/ts-results-es/actions/runs/14589373223/job/40920892340
[2] https://github.com/actions/setup-node/issues/1275