### PR TITLE
Make Async{Option,Result} thenable/awaitable

### DIFF
--- a/docs/reference/asyncoption.rst
+++ b/docs/reference/asyncoption.rst
@@ -8,6 +8,8 @@ the moment when you're ready to extract the final ``Option`` out of it.
 
 Can also be combined with synchronous code for convenience.
 
+``AsyncOption`` is awaitable - see `then()`_ for details.
+
 .. code-block:: typescript
 
     // T is the value type
@@ -136,8 +138,32 @@ Example:
 
 A promise that resolves to a synchronous ``Option``.
 
-Await it to convert ``AsyncOption<T>`` to ``Option<T>``.
+You can await it to convert ``AsyncOption<T>`` to ``Option<T>``, but prefer
+awaiting ``AsyncOption`` directly (see: `then()`_). Only use this property
+if you need the underlying Promise for specific use cases.
 
+``then()``
+----------
+
+.. code-block:: typescript
+
+    then<TResult1 = Option<T>, TResult2 = never>(
+        onfulfilled?: ((value: Option<T>) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2>
+
+Makes ``AsyncOption`` awaitable by implementing the thenable interface.
+This allows you to use ``await`` directly on ``AsyncOption`` instances.
+
+See the `Promise.then() documentation <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then>`_
+for details on the thenable interface.
+
+Example:
+
+.. code-block:: typescript
+
+    const asyncOption = new AsyncOption(Some(42))
+    const option = await asyncOption // Returns Option<number>
 
 ``toResult()``
 --------------

--- a/docs/reference/asyncoption.rst
+++ b/docs/reference/asyncoption.rst
@@ -56,7 +56,7 @@ Example:
 
     await hasValue.andThen(async (value) => Some(value * 2)).promise // Some(2)
     await hasValue.andThen(async (value) => None).promise // None
-    await noValue.andThen(async (value) => Ok(value * 2)).promise // None
+    await noValue.andThen(async (value) => Some(value * 2)).promise // None
 
 ``map()``
 ---------
@@ -74,7 +74,7 @@ Example:
 
 .. code-block:: typescript
 
-    let hasValue = Ok(1).toAsyncOption()
+    let hasValue = Some(1).toAsyncOption()
     let noValue = None.toAsyncOption()
 
     await hasValue.map(async (value) => value * 2).promise // Some(2)
@@ -132,11 +132,11 @@ Example:
 
 .. code-block:: typescript
 
-    promise: Promise<Result<T, E>>
+    promise: Promise<Option<T>>
 
-A promise that resolves to a synchronous result.
+A promise that resolves to a synchronous ``Option``.
 
-Await it to convert ``AsyncResult<T, E>`` to ``Result<T, E>``.
+Await it to convert ``AsyncOption<T>`` to ``Option<T>``.
 
 
 ``toResult()``

--- a/docs/reference/asyncresult.rst
+++ b/docs/reference/asyncresult.rst
@@ -8,6 +8,8 @@ the moment when you're ready to extract the final ``Result`` out of it.
 
 Can also be combined with synchronous code for convenience.
 
+``AsyncResult`` is awaitable - see `then()`_ for details.
+
 .. code-block:: typescript
 
     // T is the Ok value type, E is the Err error type
@@ -160,7 +162,32 @@ Example:
 
 A promise that resolves to a synchronous result.
 
-Await it to convert ``AsyncResult<T, E>`` to ``Result<T, E>``.
+You can await it to convert ``AsyncResult<T, E>`` to ``Result<T, E>``, but prefer 
+awaiting ``AsyncResult`` directly (see: `then()`_). Only use this property 
+if you need the underlying Promise for specific use cases.
+
+``then()``
+----------
+
+.. code-block:: typescript
+
+    then<TResult1 = Result<T, E>, TResult2 = never>(
+        onfulfilled?: ((value: Result<T, E>) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2>
+
+Makes ``AsyncResult`` awaitable by implementing the thenable interface.
+This allows you to use ``await`` directly on ``AsyncResult`` instances.
+
+See the `Promise.then() documentation <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then>`_ 
+for details on the thenable interface.
+
+Example:
+
+.. code-block:: typescript
+
+    const asyncResult = new AsyncResult(Ok(42))
+    const result = await asyncResult // Returns Result<number, Error>
 
 
 ``toOption()``

--- a/src/asyncoption.ts
+++ b/src/asyncoption.ts
@@ -40,7 +40,7 @@ export class AsyncOption<T> {
      *
      * await hasValue.andThen(async (value) => Some(value * 2)).promise // Some(2)
      * await hasValue.andThen(async (value) => None).promise // None
-     * await noValue.andThen(async (value) => Ok(value * 2)).promise // None
+     * await noValue.andThen(async (value) => Some(value * 2)).promise // None
      * ```
      */
     andThen<T2>(mapper: (val: T) => Option<T2> | Promise<Option<T2>> | AsyncOption<T2>): AsyncOption<T2> {
@@ -61,7 +61,7 @@ export class AsyncOption<T> {
      *
      * @example
      * ```typescript
-     * let hasValue = Ok(1).toAsyncOption()
+     * let hasValue = Some(1).toAsyncOption()
      * let noValue = None.toAsyncOption()
      *
      * await hasValue.map(async (value) => value * 2).promise // Some(2)

--- a/src/asyncoption.ts
+++ b/src/asyncoption.ts
@@ -13,7 +13,9 @@ export class AsyncOption<T> {
     /**
      * A promise that resolves to a synchronous ``Option``.
      *
-     * Await it to convert `AsyncOption<T>` to `Option<T>`.
+     * You can await it to convert `AsyncOption<T>` to `Option<T>`, but prefer
+     * awaiting `AsyncOption` directly (see: `then()`). Only use this property
+     * if you need the underlying Promise for specific use cases.
      */
     promise: Promise<Option<T>>;
 
@@ -125,6 +127,29 @@ export class AsyncOption<T> {
      */
     toResult<E>(error: E): AsyncResult<T, E> {
         return new AsyncResult(this.promise.then((option) => option.toResult(error)));
+    }
+
+    /**
+     * Makes `AsyncOption` awaitable by implementing the thenable interface.
+     * This allows you to use `await` directly on `AsyncOption` instances.
+     *
+     * See the [Promise.then() documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)
+     * for details on the thenable interface.
+     *
+     * @example
+     * ```typescript
+     * const asyncOption = new AsyncOption(Some(42))
+     * const option = await asyncOption // Returns Option<number>
+     *
+     * // Equivalent to:
+     * const option2 = await asyncOption.promise
+     * ```
+     */
+    then<TResult1 = Option<T>, TResult2 = never>(
+        onfulfilled?: ((value: Option<T>) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2> {
+        return this.promise.then(onfulfilled, onrejected);
     }
 
     private thenInternal<T2>(mapper: (option: Option<T>) => Promise<Option<T2>>): AsyncOption<T2> {

--- a/src/asyncresult.ts
+++ b/src/asyncresult.ts
@@ -13,7 +13,9 @@ export class AsyncResult<T, E> {
     /**
      * A promise that resolves to a synchronous result.
      *
-     * Await it to convert `AsyncResult<T, E>` to `Result<T, E>`.
+     * You can await it to convert `AsyncResult<T, E>` to `Result<T, E>`, but prefer
+     * awaiting `AsyncResult` directly (see: `then()`). Only use this property
+     * if you need the underlying Promise for specific use cases.
      */
     promise: Promise<Result<T, E>>;
 
@@ -152,6 +154,29 @@ export class AsyncResult<T, E> {
      */
     toOption(): AsyncOption<T> {
         return new AsyncOption(this.promise.then((result) => result.toOption()));
+    }
+
+    /**
+     * Makes `AsyncResult` awaitable by implementing the thenable interface.
+     * This allows you to use `await` directly on `AsyncResult` instances.
+     *
+     * See the [Promise.then() documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)
+     * for details on the thenable interface.
+     *
+     * @example
+     * ```typescript
+     * const asyncResult = new AsyncResult(Ok(42))
+     * const result = await asyncResult // Returns Result<number, Error>
+     *
+     * // Equivalent to:
+     * const result2 = await asyncResult.promise
+     * ```
+     */
+    then<TResult1 = Result<T, E>, TResult2 = never>(
+        onfulfilled?: ((value: Result<T, E>) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2> {
+        return this.promise.then(onfulfilled, onrejected);
     }
 
     private thenInternal<T2, E2>(mapper: (result: Result<T, E>) => Promise<Result<T2, E2>>): AsyncResult<T2, E2> {

--- a/test/asyncoption.test.ts
+++ b/test/asyncoption.test.ts
@@ -65,3 +65,15 @@ test('toResult() should work', async () => {
     const result = new AsyncOption(None);
     expect((await result.toResult('Blah').promise).unwrapErr()).toEqual('Blah');
 });
+
+test('AsyncOption should be awaitable', async () => {
+    const hasValue = new AsyncOption(Some(42));
+    const noValue = new AsyncOption(None);
+
+    // Should be able to await AsyncOption directly
+    const result1 = await hasValue;
+    expect(result1).toEqual(Some(42));
+
+    const result2 = await noValue;
+    expect(result2).toEqual(None);
+});

--- a/test/asyncresult.test.ts
+++ b/test/asyncresult.test.ts
@@ -75,3 +75,15 @@ test('toOption() should work', async () => {
     const result = new AsyncResult(Ok(1));
     expect(await result.toOption().promise).toEqual(Some(1));
 });
+
+test('AsyncResult should be awaitable', async () => {
+    const goodResult = new AsyncResult(Ok(42));
+    const badResult = new AsyncResult(Err('error'));
+
+    // Should be able to await AsyncResult directly
+    const result1 = await goodResult;
+    expect(result1).toEqual(Ok(42));
+
+    const result2 = await badResult;
+    expect(result2).toEqual(Err('error'));
+});

--- a/test/asyncresult.test.ts
+++ b/test/asyncresult.test.ts
@@ -85,5 +85,6 @@ test('AsyncResult should be awaitable', async () => {
     expect(result1).toEqual(Ok(42));
 
     const result2 = await badResult;
-    expect(result2).toEqual(Err('error'));
+    expect(result2.isErr()).toBe(true);
+    expect(result2.unwrapErr()).toEqual('error');
 });


### PR DESCRIPTION
Just a quality of life feature so we don't have to

    await x.promise

but can do

    await x

instead when converting from async to sync.