### PR TITLE
Fix Result's andThen and orElse chaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3317,11 +3317,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6597,9 +6596,9 @@
       }
     },
     "prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true
     },
     "pretty-format": {

--- a/src/result.ts
+++ b/src/result.ts
@@ -102,8 +102,6 @@ interface BaseResult<T, E> extends Iterable<T> {
      * Calls `mapper` if the result is `Ok`, otherwise returns the `Err` value of self.
      * This function can be used for control flow based on `Result` values.
      */
-    andThen<T2>(mapper: (val: T) => Ok<T2>): Result<T2, E>;
-    andThen<E2>(mapper: (val: T) => Err<E2>): Result<T, E | E2>;
     andThen<T2, E2>(mapper: (val: T) => Result<T2, E2>): Result<T2, E | E2>;
 
     /**
@@ -162,7 +160,7 @@ interface BaseResult<T, E> extends Iterable<T> {
      * Ok(1).orElse(() => Ok(2)) // => Ok(1)
      * Err('error').orElse(() => Ok(2)) // => Ok(2)
      */
-    orElse<E2>(other: (error: E) => Result<T, E2>): Result<T, E2>;
+    orElse<T2, E2>(other: (error: E) => Result<T2, E2>): Result<T | T2, E2>;
 
     /**
      *  Converts from `Result<T, E>` to `Option<T>`, discarding the error if any
@@ -263,7 +261,7 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         return this;
     }
 
-    andThen(op: unknown): Err<E> {
+    andThen<T2, E2>(op: (val: never) => Result<T2, E2>): Result<T2, E | E2> {
         return this;
     }
 
@@ -285,9 +283,7 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         return other;
     }
 
-    orElse<T>(other: (error: E) => Ok<T>): Result<T, never>;
-    orElse<R extends Result<any, any>>(other: (error: E) => R): R;
-    orElse<T, E2>(other: (error: E) => Result<T, E2>): Result<T, E2> {
+    orElse<T2, E2>(other: (error: E) => Result<T2, E2>): Result<T2, E2> {
         return other(this.error);
     }
 
@@ -379,9 +375,6 @@ export class OkImpl<T> implements BaseResult<T, never> {
         return new Ok(mapper(this.value));
     }
 
-    andThen<T2>(mapper: (val: T) => Ok<T2>): Ok<T2>;
-    andThen<E2>(mapper: (val: T) => Err<E2>): Result<T, E2>;
-    andThen<T2, E2>(mapper: (val: T) => Result<T2, E2>): Result<T2, E2>;
     andThen<T2, E2>(mapper: (val: T) => Result<T2, E2>): Result<T2, E2> {
         return mapper(this.value);
     }
@@ -402,7 +395,7 @@ export class OkImpl<T> implements BaseResult<T, never> {
         return this;
     }
 
-    orElse(_other: (error: never) => Result<T, any>): Ok<T> {
+    orElse<T2, E2>(_other: (error: never) => Result<T2, E2>): Result<T, never> {
         return this;
     }
 

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'conditional-type-checks';
-import { Err, Ok } from '../src/index.js';
+import { Err, Ok, Result } from '../src/index.js';
 import { eq, expect_never } from './util.js';
 
 test('Constructable & Callable', () => {
@@ -93,7 +93,7 @@ test('map', () => {
 test('andThen', () => {
     const err = new Err('Err').andThen(() => new Ok(3));
     expect(err).toMatchResult(Err('Err'));
-    eq<typeof err, Err<string>>(true);
+    eq<typeof err, Result<number, unknown>>(true);
 });
 
 test('mapErr', () => {

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -90,11 +90,11 @@ test('map', () => {
 test('andThen', () => {
     const ok = new Ok('Ok').andThen(() => new Ok(3));
     expect(ok).toMatchResult(Ok(3));
-    eq<typeof ok, Ok<number>>(true);
+    eq<typeof ok, Result<number, unknown>>(true);
 
     const err = new Ok('Ok').andThen(() => new Err(false));
     expect(err).toMatchResult(Err(false));
-    eq<typeof err, Result<string, boolean>>(true);
+    eq<typeof err, Result<unknown, boolean>>(true);
 });
 
 test('mapErr', () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -328,6 +328,13 @@ test('unwrapOrElse', () => {
     expect(Err('bad error').unwrapOrElse((error) => ({ error }))).toEqual({ error: 'bad error' });
 });
 
+export function passNonEmptyArray<T>(array: T[]): Result<T[], string> {
+    if (array.length === 0) {
+        return Err('The array is empty')
+    }
+    return Ok(array)
+}
+
 test('andThen/orElse chaining regression', () => {
     // Based on this issue: https://github.com/lune-climate/ts-results-es/issues/197
     class T1 {
@@ -372,4 +379,7 @@ test('andThen/orElse chaining regression', () => {
 
     expect(test2).toEqual(Ok({ name: 'T3' }));
     eq<typeof test2, Ok<T3> | Err<E3> | Err<E2 | E3>>(true);
+
+    const y: Result<({ id: number } & { name: string } & { [key: string]: unknown })[], string> = Ok([{ id: 1, name: 'John' }]);
+    const z = y.andThen(passNonEmptyArray)
 });

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -359,6 +359,10 @@ test('andThen/orElse chaining regression', () => {
         return Ok({ name: 'T3' });
     }
 
+    // The orElse line used to produce this error:
+    //
+    // This expression is not callable.
+    // Each member of the union type ... has signatures, but none of those signatures are compatible with each other. (ts 2349)
     const test1 = foo1()
         .andThen(() => foo2())
         .orElse(() => foo3());
@@ -366,6 +370,7 @@ test('andThen/orElse chaining regression', () => {
     expect(test1).toEqual(Ok({ name: 'T2' }));
     eq<typeof test1, Ok<T2> | Ok<T3> | Err<E3>>(true);
 
+    // Test the opposite order too just to be sure
     const test2 = foo1()
         .orElse(() => foo2())
         .andThen(() => foo3());

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -328,13 +328,6 @@ test('unwrapOrElse', () => {
     expect(Err('bad error').unwrapOrElse((error) => ({ error }))).toEqual({ error: 'bad error' });
 });
 
-export function passNonEmptyArray<T>(array: T[]): Result<T[], string> {
-    if (array.length === 0) {
-        return Err('The array is empty')
-    }
-    return Ok(array)
-}
-
 test('andThen/orElse chaining regression', () => {
     // Based on this issue: https://github.com/lune-climate/ts-results-es/issues/197
     class T1 {
@@ -379,7 +372,4 @@ test('andThen/orElse chaining regression', () => {
 
     expect(test2).toEqual(Ok({ name: 'T3' }));
     eq<typeof test2, Ok<T3> | Err<E3> | Err<E2 | E3>>(true);
-
-    const y: Result<({ id: number } & { name: string } & { [key: string]: unknown })[], string> = Ok([{ id: 1, name: 'John' }]);
-    const z = y.andThen(passNonEmptyArray)
 });


### PR DESCRIPTION
It's been reported that code like this didn't work:

    class T1 { name = "T1" as const }
    class T2 { name = "T2" as const }
    class T3 { name = "T3" as const }
    class T4 { name = "T4" as const }
    class T5 { name = "T5" as const }
    class T6 { name = "T6" as const }

    function foo1(): Result<T1, T2> {
      return 0 as any
    }
    function foo2(): Result<T3, T4> {
      return 0 as any
    }
    function foo3(): Result<T5, T6> {
      return 0 as any
    }

    const a = foo1().andThen(foo2).orElse(foo3) // error

because orElse wasn't callable on the result of the andThen call ("This expression is not callable"):

    This expression is not callable.
    Each member of the union type '{ <T>(other: (error: T2) => Ok<T>): Result<T, never>; <R extends Result<any, any>>(other: (error: T2) => R): R; } | { <T>(other: (error: T4) => Ok<T>): Result<...>; <R extends Result<any, any>>(other: (error: T4) => R): R; } | ((_other: (error: never) => Result<...>) => Ok<...>)' has signatures, but none of those signatures are compatible with each other. (ts 2349)

As far as I can tell that was because of the different andThen and orElse overloads with different numbers of type parameters which complicated things for us.

The overloads were meant to narrow types if we knew

a) What types were we dealing with initially (full Result or just Ok or
   Err)
b) What did the mapper functions return (Result or always Ok or Err)

While it was nice to narrow the types like that it complicated things for us and caused (or contributed to) the problem reported above.

This patch has two backwards compatibility regressions. I don't see how we can fix the general (serious) problem while handling these edge cases well:

1. We lose the type narrowing as described above.
2. This patch also introduces a regression in inferring types
   of generic functions:

        // someGenericFunction<T>(...): Result<...>
        result.andThen(someGenericFunction)

   which is unfortunate but can be worked around like so:

       result.andThen((v) => someGenericFunction(v))

Possible workarounds if someone wants to keep calling orElse and andThen with always-Ok or always-Err mappers:

* andThen + always Ok -> map
* andThen + always Err -> not sure, maybe change what returned Ok earlier to not do that, depends on the situation
* orElse + always Ok -> unwrapOr
* orElse + always Err -> mapErr

All of the above will be documented in the changelog before publishing ts-results-es with this patch.

[1] da3abf8e566e ("Fix for Issue#24")

Fixes: https://github.com/lune-climate/ts-results-es/issues/197