### PR TITLE
Make object Result.all short-circuit by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 Added:
 
 - Added object overload for `Result.all`, accepting any object type with
-  `Result` values (preserving per-key types). Unlike the array variant, it
-  does not short-circuit and collects all errors.
+  `Result` values (preserving per-key types). By default, it short-circuits
+  with the first error and returns the property name and error. Passing
+  `{ errors: 'all' }` collects all errors.
 
 # 7.0.0
 

--- a/docs/reference/result.rst
+++ b/docs/reference/result.rst
@@ -37,7 +37,22 @@ to combine results with asynchronouse code.
     static all(results: Result<T, E>[]): Result<T[], E>
 
     // Object overload (accepts any object type with Result values, preserving per-key types)
-    static all<T extends Record<string, Result<any, any>>>(results: T): Result<ResultOkTypesRecord<T>, Partial<ResultErrTypesRecord<T>>>
+    static all<const T extends Record<string, Result<any, any>>>(
+        results: T,
+    ): Result<ResultOkTypesRecord<T>, ResultErrEntry<T>>
+
+    static all<const T extends Record<string, Result<any, any>>>(
+        results: T,
+        options: { errors?: 'first' },
+    ): Result<ResultOkTypesRecord<T>, ResultErrEntry<T>>
+
+    static all<const T extends Record<string, Result<any, any>>>(
+        results: T,
+        options: { errors: 'all' },
+    ): Result<
+        ResultOkTypesRecord<T>,
+        Partial<ResultErrTypesRecord<T>>
+    >
 
 Parse a set of ``Result``, returning an array of all ``Ok`` values.
 Short circuits with the first ``Err`` found, if any.
@@ -45,9 +60,12 @@ Short circuits with the first ``Err`` found, if any.
 When called with an object:
 
 Parse an object of ``Result``\s, returning an object of all ``Ok`` values.
-If any ``Result`` is ``Err``, returns an ``Err`` containing an object of all errors
-(only keys that were ``Err`` are present). Unlike the array variant, it does not
-short-circuit and collects all errors.
+By default, it short-circuits with the first ``Err`` and returns an ``Err``
+containing the property name and error. When multiple inputs are ``Err``,
+callers must not rely on which ``Err`` is returned. Passing ``{}`` or
+``{ errors: 'first' }`` makes the default short-circuit behavior explicit.
+Passing ``{ errors: 'all' }`` collects all errors into an object where only keys
+that were ``Err`` are present.
 
 Array example:
 
@@ -59,16 +77,70 @@ Array example:
 
     let toppings = result.unwrap(); // toppings is an array of Topping.  Could throw GetToppingsError.
 
-Object example:
+Successful object example:
 
 .. code-block:: typescript
 
+    const name: Result<string, NameError> = Ok('Alice');
+    const age: Result<number, AgeError> = Ok(36);
+
     let result = Result.all({
-        name: validateName(input.name),  // Result<string, NameError>
-        age: validateAge(input.age),     // Result<number, AgeError>
+        name,
+        age,
     });
-    // Ok({ name: 'Alice', age: 25 }),
-    // type: Result<{ name: string; age: number }, Partial<{ name: NameError; age: AgeError }>>
+    // Ok({ name: 'Alice', age: 36 })
+    // type: Result<
+    //     { name: string; age: number },
+    //     { key: 'name'; error: NameError } | { key: 'age'; error: AgeError }
+    // >
+
+Short-circuiting object errors:
+
+.. code-block:: typescript
+
+    const invalidName: Result<string, NameError> = Err(nameError);
+    const invalidAge: Result<number, AgeError> = Err(ageError);
+
+    let result = Result.all({
+        name: invalidName,
+        age: invalidAge,
+    });
+    // Err({ key: 'name', error: nameError }) or
+    // Err({ key: 'age', error: ageError }); callers must not depend on
+    // which one is returned when multiple inputs are Err.
+    // type: Result<
+    //     { name: string; age: number },
+    //     { key: 'name'; error: NameError } | { key: 'age'; error: AgeError }
+    // >
+
+    let explicitFirst = Result.all({
+        name: invalidName,
+        age: invalidAge,
+    }, { errors: 'first' });
+    // Same behavior and type as the default short-circuit call above.
+
+    let omittedErrors = Result.all({
+        name: invalidName,
+        age: invalidAge,
+    }, {});
+    // Same behavior and type as the default short-circuit call above.
+
+Collecting all object errors:
+
+.. code-block:: typescript
+
+    const invalidName: Result<string, NameError> = Err(nameError);
+    const invalidAge: Result<number, AgeError> = Err(ageError);
+
+    let result = Result.all({
+        name: invalidName,
+        age: invalidAge,
+    }, { errors: 'all' });
+    // Err({ name: nameError, age: ageError })
+    // type: Result<
+    //     { name: string; age: number },
+    //     Partial<{ name: NameError; age: AgeError }>
+    // >
 
 .. _method-Result-andThen:
 
@@ -296,6 +368,38 @@ Example:
 
     type Input = { name: Result<string, Error>; age: Result<number, TypeError> }
     type Output = ResultErrTypesRecord<Input> // { name: Error; age: TypeError }
+
+.. _type-ResultErrEntry:
+
+``ResultErrEntry``
+------------------
+
+.. code-block:: typescript
+
+    type ResultErrEntry<T extends Record<string, Result<any, any>>>
+
+Extracts the keyed first error returned when combining an object of ``Result``\s.
+
+Example:
+
+.. code-block:: typescript
+
+    type FormFields = {
+        name: Result<string, NameError>;
+        age: Result<number, AgeError>;
+    };
+
+    type FieldError = ResultErrEntry<FormFields>;
+    // { key: 'name'; error: NameError } | { key: 'age'; error: AgeError }
+
+    function messageFor(error: FieldError): string {
+        switch (error.key) {
+            case 'name':
+                return formatNameError(error.error);
+            case 'age':
+                return formatAgeError(error.error);
+        }
+    }
 
 .. _attribute-Err-error:
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -556,6 +556,34 @@ export type ResultErrTypesRecord<T extends Record<string, Result<any, any>>> = {
     [key in keyof T]: ResultErrType<T[key]>;
 };
 
+/**
+ * Extracts the keyed first error returned when combining
+ * an object of `Result`s.
+ *
+ * @example
+ * ```typescript
+ * type FormFields = {
+ *     name: Result<string, NameError>;
+ *     age: Result<number, AgeError>;
+ * };
+ *
+ * type FieldError = ResultErrEntry<FormFields>;
+ * // { key: 'name'; error: NameError } | { key: 'age'; error: AgeError }
+ *
+ * function messageFor(error: FieldError): string {
+ *     switch (error.key) {
+ *         case 'name':
+ *             return formatNameError(error.error);
+ *         case 'age':
+ *             return formatAgeError(error.error);
+ *     }
+ * }
+ * ```
+ */
+export type ResultErrEntry<T extends Record<string, Result<any, any>>> = {
+    [key in keyof T]: ResultErrType<T[key]> extends never ? never : { key: key; error: ResultErrType<T[key]> };
+}[keyof T];
+
 export namespace Result {
     /**
      * Parse a set of `Result`s, returning an array of all `Ok` values.
@@ -575,24 +603,83 @@ export namespace Result {
     ): Result<ResultOkTypes<T>, ResultErrTypes<T>[number]>;
     /**
      * Parse an object of `Result`s, returning an object of all `Ok` values.
-     * If any `Result` is `Err`, returns an `Err` containing an object of all errors
-     * (only keys that were `Err` are present). Unlike the array variant, it does not
-     * short-circuit and collects all errors.
+     * By default it short-circuits with the first `Err`, returning the property
+     * name and error. When multiple inputs are `Err`, callers must not rely on
+     * which `Err` is returned. Passing `{}` or `{ errors: 'first' }` makes the
+     * default short-circuit behavior explicit. Passing `{ errors: 'all' }`
+     * collects all errors into an object where only keys that were `Err` are
+     * present.
      *
      * @example
      * ```typescript
-     * let result = Result.all({
-     *     name: validateName(input.name),  // Result<string, NameError>
-     *     age: validateAge(input.age),     // Result<number, AgeError>
+     * const name: Result<string, NameError> = Ok('Alice');
+     * const age: Result<number, AgeError> = Ok(36);
+     *
+     * const parsed = Result.all({
+     *     name,
+     *     age,
      * });
-     * // Ok({ name: 'Alice', age: 25 }),
-     * // type: Result<{ name: string; age: number }, Partial<{ name: NameError; age: AgeError }>>
+     * // Ok({ name: 'Alice', age: 36 })
+     * // type: Result<
+     * //     { name: string; age: number },
+     * //     { key: 'name'; error: NameError } | { key: 'age'; error: AgeError }
+     * // >
+     *
+     * const invalidName: Result<string, NameError> = Err(nameError);
+     * const invalidAge: Result<number, AgeError> = Err(ageError);
+     *
+     * const firstError = Result.all({
+     *     name: invalidName,
+     *     age: invalidAge,
+     * });
+     * // Err({ key: 'name', error: nameError }) or
+     * // Err({ key: 'age', error: ageError }); callers must not depend on
+     * // which one is returned when multiple inputs are Err.
+     * // type: Result<
+     * //     { name: string; age: number },
+     * //     { key: 'name'; error: NameError } | { key: 'age'; error: AgeError }
+     * // >
+     *
+     * const sameFirstError = Result.all({
+     *     name: invalidName,
+     *     age: invalidAge,
+     * }, { errors: 'first' });
+     * // Same behavior and type as the default short-circuit call above.
+     *
+     * const omittedErrors = Result.all({
+     *     name: invalidName,
+     *     age: invalidAge,
+     * }, {});
+     * // Same behavior and type as the default short-circuit call above.
+     *
+     * const allErrors = Result.all({
+     *     name: invalidName,
+     *     age: invalidAge,
+     * }, { errors: 'all' });
+     * // Err({ name: nameError, age: ageError })
+     * // type: Result<
+     * //     { name: string; age: number },
+     * //     Partial<{ name: NameError; age: AgeError }>
+     * // >
      * ```
      */
     export function all<const T extends Record<string, Result<any, any>>>(
         results: T,
+    ): Result<ResultOkTypesRecord<T>, ResultErrEntry<T>>;
+    export function all<const T extends Record<string, Result<any, any>>>(
+        results: T,
+        options: { errors?: 'first' },
+    ): Result<ResultOkTypesRecord<T>, ResultErrEntry<T>>;
+    export function all<const T extends Record<string, Result<any, any>>>(
+        results: T,
+        options: { errors: 'all' },
     ): Result<ResultOkTypesRecord<T>, Partial<ResultErrTypesRecord<T>>>;
-    export function all(results: Result<any, any>[] | Record<string, Result<any, any>>): Result<any, any> {
+    // Options whose mode is not known at compile time are intentionally not
+    // supported because the return error shape depends on that mode.
+    export function all(
+        results: Result<any, any>[] | Record<string, Result<any, any>>,
+        options?: { errors?: 'first' | 'all' },
+    ): Result<any, any> {
         if (Array.isArray(results)) {
             const okResult = [];
             for (const result of results) {
@@ -603,7 +690,7 @@ export namespace Result {
                 }
             }
             return new Ok(okResult);
-        } else {
+        } else if (options !== undefined && options.errors === 'all') {
             const okResult: Record<string, any> = {};
             const errResult: Record<string, any> = {};
             let hasErr = false;
@@ -616,6 +703,16 @@ export namespace Result {
                 }
             }
             return hasErr ? new Err(errResult) : new Ok(okResult);
+        } else {
+            const okResult: Record<string, any> = {};
+            for (const [key, result] of Object.entries(results)) {
+                if (result.isOk()) {
+                    okResult[key] = result.value;
+                } else {
+                    return new Err({ key, error: result.error });
+                }
+            }
+            return new Ok(okResult);
         }
     }
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -4,6 +4,7 @@ import {
     Ok,
     Option,
     Result,
+    ResultErrEntry,
     ResultErrType,
     ResultErrTypes,
     ResultErrTypesRecord,
@@ -147,35 +148,148 @@ test('Result.all with object', () => {
     // Empty object
     const all0 = Result.all({});
     expect(all0).toMatchResult(Ok({}));
-    eq<typeof all0, Result<{}, Partial<{}>>>(true);
+    eq<typeof all0, Result<{}, never>>(true);
+
+    const all0AllErrors = Result.all({}, { errors: 'all' });
+    expect(all0AllErrors).toMatchResult(Ok({}));
+    eq<typeof all0AllErrors, Result<{}, Partial<{}>>>(true);
 
     // All Ok
     const all1 = Result.all({ a: ok0, b: ok1 });
     expect(all1).toMatchResult(Ok({ a: 3, b: true }));
-    eq<typeof all1, Result<{ a: number; b: boolean }, Partial<{ a: string; b: number }>>>(true);
+    eq<typeof all1, Result<{ a: number; b: boolean }, { key: 'a'; error: string } | { key: 'b'; error: number }>>(true);
+
+    const all1KnownOk = Result.all({ a: Ok(3), b: Ok(true) });
+    expect(all1KnownOk).toMatchResult(Ok({ a: 3, b: true }));
+    eq<typeof all1KnownOk, Result<{ a: number; b: boolean }, never>>(true);
+
+    const all1AllErrors = Result.all({ a: ok0, b: ok1 }, { errors: 'all' });
+    expect(all1AllErrors).toMatchResult(Ok({ a: 3, b: true }));
+    eq<typeof all1AllErrors, Result<{ a: number; b: boolean }, Partial<{ a: string; b: number }>>>(true);
 
     // All Err
     const all2 = Result.all({ a: err0, b: err1 });
     expect(all2).toMatchResult(
         Err({
+            key: 'a',
+            error: sym,
+        }),
+    );
+    eq<typeof all2, Result<{ a: string; b: number }, { key: 'a'; error: symbol } | { key: 'b'; error: Error }>>(true);
+
+    const all2AllErrors = Result.all({ a: err0, b: err1 }, { errors: 'all' });
+    expect(all2AllErrors).toMatchResult(
+        Err({
             a: sym,
             b: error,
         }),
     );
-    eq<typeof all2, Result<{ a: string; b: number }, Partial<{ a: symbol; b: Error }>>>(true);
+    eq<typeof all2AllErrors, Result<{ a: string; b: number }, Partial<{ a: symbol; b: Error }>>>(true);
 
     // Mixed
     const all3 = Result.all({ a: ok0, b: err0, c: ok1, d: err1 });
     expect(all3).toMatchResult(
+        Err({
+            key: 'b',
+            error: sym,
+        }),
+    );
+    eq<
+        typeof all3,
+        Result<
+            { a: number; b: string; c: boolean; d: number },
+            | { key: 'a'; error: string }
+            | { key: 'b'; error: symbol }
+            | { key: 'c'; error: number }
+            | { key: 'd'; error: Error }
+        >
+    >(true);
+
+    const all3FirstError = Result.all({ a: ok0, b: err0, c: ok1, d: err1 }, { errors: 'first' });
+    expect(all3FirstError).toMatchResult(
+        Err({
+            key: 'b',
+            error: sym,
+        }),
+    );
+    eq<
+        typeof all3FirstError,
+        Result<
+            { a: number; b: string; c: boolean; d: number },
+            | { key: 'a'; error: string }
+            | { key: 'b'; error: symbol }
+            | { key: 'c'; error: number }
+            | { key: 'd'; error: Error }
+        >
+    >(true);
+
+    const all3OmittedErrors = Result.all({ a: ok0, b: err0, c: ok1, d: err1 }, {});
+    expect(all3OmittedErrors).toMatchResult(
+        Err({
+            key: 'b',
+            error: sym,
+        }),
+    );
+    eq<
+        typeof all3OmittedErrors,
+        Result<
+            { a: number; b: string; c: boolean; d: number },
+            | { key: 'a'; error: string }
+            | { key: 'b'; error: symbol }
+            | { key: 'c'; error: number }
+            | { key: 'd'; error: Error }
+        >
+    >(true);
+
+    const all3KnownOk = Result.all({ a: Ok(3), b: err0, c: Ok(true), d: err1 });
+    expect(all3KnownOk).toMatchResult(
+        Err({
+            key: 'b',
+            error: sym,
+        }),
+    );
+    eq<
+        typeof all3KnownOk,
+        Result<
+            { a: number; b: string; c: boolean; d: number },
+            { key: 'b'; error: symbol } | { key: 'd'; error: Error }
+        >
+    >(true);
+    eq<
+        ResultErrEntry<{ a: Ok<number>; b: typeof err0; c: Ok<boolean>; d: typeof err1 }>,
+        { key: 'b'; error: symbol } | { key: 'd'; error: Error }
+    >(true);
+
+    const all3AllErrors = Result.all({ a: ok0, b: err0, c: ok1, d: err1 }, { errors: 'all' });
+    expect(all3AllErrors).toMatchResult(
         Err({
             b: sym,
             d: error,
         }),
     );
     eq<
-        typeof all3,
+        typeof all3AllErrors,
         Result<{ a: number; b: string; c: boolean; d: number }, Partial<{ a: string; b: symbol; c: number; d: Error }>>
     >(true);
+});
+
+test('Result.all with object narrows first error by key', () => {
+    function f(a: Result<string, number>, b: Result<number, boolean>): void {
+        const all = Result.all({ a, b });
+        eq<typeof all, Result<{ a: string; b: number }, { key: 'a'; error: number } | { key: 'b'; error: boolean }>>(
+            true,
+        );
+
+        if (all.isErr()) {
+            if (all.error.key === 'a') {
+                eq<typeof all.error.error, number>(true);
+            } else {
+                eq<typeof all.error.error, boolean>(true);
+            }
+        }
+    }
+
+    f(Err(1), Err(false));
 });
 
 test('Result.any', () => {


### PR DESCRIPTION
When I implemented the Result.all overload for objects in [1] I only implemented the gather-all-errors mode but since then I realized in some cases we only want the first error (any error) so failing fast makes sense there.

I think it's reasonable for the default behavior to be short-circuiting as well so this is what the patch does (adds the short-circuit mode + makes it the default). The overload hasn't been released yet so it's fine to change the behavior like that.

The other mode is still available via the errors switch.

[1] 904d54a8da29 ("Add object overload for Result.all (#257)")