### PR TITLE
Add Dependabot update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
It should prevent us from accidentally updating to freshly-released packages with malware in them.

This does not affect Dependabot security updates.