### PR TITLE
FEAT: add unwrapOrThrow and its unit tests

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -83,6 +83,36 @@ interface BaseResult<T, E> extends Iterable<T> {
     unwrap(): T;
 
     /**
+     * Returns the contained `Ok` value.
+     *
+     * Throws the contained `Err` value directly when this result is an `Err`.
+     * Unlike `unwrap()`, it does not wrap the error in a new `Error`.
+     *
+     * @throws The original error contained in `Err`.
+     *
+     * @example
+     * ```typescript
+     *  class MyCustomError extends Error {
+     *      constructor(message: string) {
+     *          super(message);
+     *          Object.setPrototypeOf(this, MyCustomError.prototype);
+     *      }
+     *  }
+     *
+     * const goodResult = new Ok(1);
+     * const badResult = new Err(new MyCustomError("my custom error."));
+     *
+     * goodResult.unwrapOrThrow(); // 1
+     * badResult.unwrapOrThrow();  // throws the original MyCustomError instance directly
+     * //----------------------------------
+     * badResult.unwrap();
+     * // throws a new Error("my custom error.")
+     * // with badResult's MyCustomError available as error.cause
+     * ```
+     */
+    unwrapOrThrow(): T;
+
+    /**
      * Returns the contained `Err` value.
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `Ok` case explicitly and access the `error` property
@@ -353,7 +383,9 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         // See https://github.com/microsoft/TypeScript/issues/45167
         throw new Error(`Tried to unwrap Error: ${toString(this.error)}\n${this._stack}`, { cause: this.error as any });
     }
-
+    unwrapOrThrow(): never {
+        throw this.error;
+    }
     unwrapErr(): E {
         return this.error;
     }
@@ -464,7 +496,9 @@ export class OkImpl<T> implements BaseResult<T, never> {
     unwrap(): T {
         return this.value;
     }
-
+    unwrapOrThrow(): T {
+        return this.value;
+    }
     unwrapErr(): never {
         // The cause casting required because of the current TS definition being overly restrictive
         // (the definition says it has to be an Error while it can be anything).

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -73,7 +73,28 @@ test('unwrap', () => {
         expect((e as Error).cause).toEqual({ message: 'bad error' });
     }
 });
+test('unwrapOrThrow throws the original error', () => {
+    const originalError = new Error('direct error');
 
+    try {
+        Err(originalError).unwrapOrThrow();
+        throw new Error('Unreachable');
+    } catch (error) {
+        expect(error).toBe(originalError);
+    }
+});
+
+test('unwrapOrThrow preserves custom error type', () => {
+    class MyCustomError extends Error {
+        constructor(message: string) {
+            super(message);
+            Object.setPrototypeOf(this, MyCustomError.prototype);
+        }
+    }
+    const originalError = Err(new MyCustomError('my direct custom error.'));
+
+    expect(() => originalError.unwrapOrThrow()).toThrow(MyCustomError);
+});
 test('unwrapErr', () => {
     const err = Err(1).unwrapErr();
     expect(err).toBe(1);

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -65,7 +65,11 @@ test('unwrap', () => {
     expect(val).toBe(true);
     eq<boolean, typeof val>(true);
 });
-
+test('unwrapOrThrow', () => {
+    const val = Ok(true).unwrapOrThrow();
+    expect(val).toBe(true);
+    eq<boolean, typeof val>(true);
+});
 test('unwrapErr', () => {
     try {
         const err = Ok('boom').unwrapErr();


### PR DESCRIPTION
## Motivation

`unwrap()` creates a new `Error` when the `Result` is an `Err`. This is useful when additional context is desired, but it can be inconvenient when callers need to preserve the original error instance and type.

## Use cases

`unwrapOrThrow()` is useful when callers want to:

- Throw the original custom error unchanged.
- Preserve the original error type for `instanceof` checks.
- Preserve the original error identity and metadata.
- Avoid wrapping errors when rethrowing them.
- In a NestJS application, a custom exception filter can catch the original error and map its type or properties to the appropriate HTTP status code and API response.

## Behavior

- On `Ok`, returns the contained value.
- On `Err`, throws the contained error directly without wrapping it.

```ts
const error = new MyCustomError("something went wrong");
Err(error).unwrapOrThrow(); // throws the same error instance
```
Closes #286 
This complements `unwrap()`, which continues to wrap the contained error with additional context.